### PR TITLE
feat: add 2 CSS helper methods

### DIFF
--- a/lib/__tests__/css-helper.test.ts
+++ b/lib/__tests__/css-helper.test.ts
@@ -32,6 +32,14 @@ describe('css-help', () => {
       );
     });
   });
+  describe('getStyleAny', () => {
+    it('should return an ExtendedCSSStyleDeclartion object of length 1', () => {
+      expect(t.getStyleAny(['.earth', '.sky'])?.length).toEqual(1);
+    });
+    it('should return null', () => {
+      expect(t.getStyleAny(['.sun', '.earth', '.moon'])).toBeNull();
+    });
+  });
   describe('isPropertyUsed', () => {
     it('should return true on existing properties', () => {
       expect(t.isPropertyUsed('height')).toBeTruthy();

--- a/lib/__tests__/css-helper.test.ts
+++ b/lib/__tests__/css-helper.test.ts
@@ -100,6 +100,37 @@ describe('css-help', () => {
       );
     });
   });
+  describe('selectorsFromSelector', () => {
+    it('should return an empty array', () => {
+      setupDocument();
+      expect(t.selectorsFromSelector('.void')).toEqual([]);
+    });
+    it('should return an array with 9 members', () => {
+      setupDocument();
+      expect(t.selectorsFromSelector('a')).toEqual([
+        'a',
+        'label > a',
+        'label a',
+        'form > label > a',
+        'form label a',
+        'body > form > label > a',
+        'body form label a',
+        'html > body > form > label > a',
+        'html body form label a',
+      ]);
+    });
+
+    function setupDocument() {
+      const form = doc.createElement('form');
+      form.innerHTML = `
+        <label>
+          <input type="checkbox" /> I accept the <a href="#">terms and conditions</a>
+        </label>
+        <input type="submit" value="Submit" />
+      `;
+      doc.body.appendChild(form);
+    }
+  });
   afterEach(() => {
     document.body.innerHTML = '';
     document.head.innerHTML = '';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -212,4 +212,37 @@ export class CSSHelp {
   ): CSSRule[] {
     return Array.from(styleSheet?.cssRules || []);
   }
+  // takes a CSS selector, returns all equivelant selectors from the current document
+  // or an empty array if there are no matches
+  selectorsFromSelector(selector: string): string[] {
+    const elements = this.doc.querySelectorAll(selector);
+    const allSelectors = Array.from(elements).map((element: Element) => {
+      let directPath = [];
+      let indirectPath = [];
+      let allPaths = [];
+
+      while (element.parentNode) {
+        let tag = element.tagName.toLowerCase();
+        let siblings = Array.from(element.parentNode.children);
+
+        if (siblings.filter(e => e.tagName === element.tagName).length > 1) {
+          let allSiblings = Array.from(element.parentNode.childNodes);
+          let index = allSiblings.indexOf(element);
+          tag += `:nth-child(${index + 1})`;
+        }
+
+        directPath.unshift(tag);
+        indirectPath.unshift(tag);
+        allPaths.push([directPath.join(' > '), indirectPath.join(' ')]);
+        
+        // traverse up the DOM tree
+        element = element.parentNode as Element;
+      }
+
+      return allPaths.flat();
+    }).flat();
+
+    // remove duplicates
+    return [...new Set(allSelectors)];
+  }
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -128,6 +128,18 @@ export class CSSHelp {
     };
     return style;
   }
+  // A wrapper around getStyle for testing challenges where multiple CSS selectors are valid
+  getStyleAny(selectors: string[]): ExtendedStyleDeclaration | null {
+    for (const selector of selectors) {
+      const style = this.getStyle(selector);
+      
+      if (style) {
+        return style;
+      }
+    }
+
+    return null;
+  }
   getStyleRule(selector: string): ExtendedStyleRule | null {
     const styleRule = this._getStyleRules()?.find(
       ele => ele?.selectorText === selector


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
Add two new methods to the `CSSHelp` class for testing challenges where multiple CSS selectors are valid. Example: https://github.com/freeCodeCamp/freeCodeCamp/pull/52379