### PR TITLE
fix: match defs at end of string

### DIFF
--- a/lib/__tests__/python.test.ts
+++ b/lib/__tests__/python.test.ts
@@ -6,7 +6,7 @@ describe("python", () => {
     const code = `
 a = 1
 
-def b():
+def b(d, e):
   a = 2
 
 def c():
@@ -16,13 +16,12 @@ def c():
     if (match) {
       const { def, function_indentation, function_body, function_parameters } =
         match;
-      expect(def).toEqual(`
-
-def b():
-  a = 2`);
+      expect(def).toEqual(`def b(d, e):
+  a = 2
+`);
       expect(function_indentation).toEqual(0);
-      expect(function_body).toEqual("  a = 2");
-      expect(function_parameters).toEqual("");
+      expect(function_body).toEqual("  a = 2\n");
+      expect(function_parameters).toEqual("d, e");
     }
   });
 });

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -100,7 +100,7 @@ const getIsDeclaredAfter = (styleRule: CSSStyleRule) => (selector: string) => {
 export module python {
   export function getDef(code: string, functionName: string) {
     const regex = new RegExp(
-      `\\n(?<function_indentation>\\s*?)def\\s+${functionName}\\s*\\((?<function_parameters>[^\\)]*)\\)\\s*:\\n(?<function_body>.*?)(?=\\n\\k<function_indentation>[\\w#])`,
+      `\\n(?<function_indentation> *?)def +${functionName} *\\((?<function_parameters>[^\\)]*)\\)\\s*:\\n(?<function_body>.*?)(?=\\n\\k<function_indentation>[\\w#]|$)`,
       "s"
     );
 
@@ -114,7 +114,8 @@ export module python {
         ""
       );
       return {
-        def: matchedCode[0],
+        // Entire function definition without additional \n
+        def: matchedCode[0].slice(1),
         function_parameters,
         function_body,
         function_indentation: functionIndentationSansNewLine.length,


### PR DESCRIPTION
This fixes issues where:
- Function is defined at end of string
  - There are no word/`#` characters
- Technically, Python functions cannot have new line characters in the `def name(` part
  - Only `' '` (space) characters
  - **Note:** Surprisingly, there can be new line characters within the function params 🤷‍♂️ (_WHY PYTHON! WHY!_)
- The function `def` return no longer includes the superfluous `\n`
