### PR TITLE
fix: set webpack global Object to "this"

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,7 @@ module.exports = {
   },
   devtool: process.env.NODE_ENV ? "source-map" : "inline-source-map",
   output: {
+    globalObject: 'this',
     library: {
       name: "helpers",
       type: "umd",


### PR DESCRIPTION
> When targeting a library, especially when libraryTarget is 'umd', this option indicates what global object will be used to mount the library. To make UMD build available on both browsers and Node.js, set output.globalObject option to 'this'. Defaults to self for Web-like targets.

> The return value of your entry point will be assigned to the global object using the value of output.library.name. Depending on the value of the target option, the global object could change respectively, e.g., self, global, or globalThis.

https://webpack.js.org/configuration/output/

We should probably set the other values as well?