### PR TITLE
fix: adjust module to point to dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "/dist"
   ],
   "main": "dist/",
-  "module": "lib/index.ts",
+  "module": "dist/index.js",
   "keywords": [
     ""
   ],


### PR DESCRIPTION
Fixes:

```bash
../../../node_modules/.pnpm/github.com+freeCodeCamp+curriculum-helpers@f89513ae5...(truncated) 9.89 KiB [built] [1 error]

ERROR in ../../../node_modules/.pnpm/github.com+freeCodeCamp+curriculum-helpers@f89513ae508a4f984d35ed51758af95a33085338_xp55akxy2pcq7r6narzzjrjzm4/node_modules/@freecodecamp/curriculum-helpers/lib/index.ts 9:38
Module parse failed: Unexpected token (9:38)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
|  */
|
> export function removeHtmlComments(str: string): string {
|   return str.replace(/<!--[\s\S]*?(-->|$)/g, "");
| }
 @ ./frame-runner.ts 2:0-60 54:20-27

webpack 5.89.0 compiled with 1 error in 769 ms
/home/shauh/freeCodeCamp/tools/client-plugins/browser-scripts:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @freecodecamp/browser-scripts@1.0.0 build: `cross-env NODE_OPTIONS="--max-old-space-size=7168" webpack -c webpack.config.js "--env" "development"`
 ```

Where freeCodeCamp thinks it should build with the TS files.