### PR TITLE
fix: output multiple targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "/dist"
   ],
   "main": "dist/",
-  "module": "dist/index.js",
+  "module": "dist/index.browser.js",
   "keywords": [
     ""
   ],
@@ -61,7 +61,8 @@
     "build": "NODE_ENV=production webpack",
     "lint": "eslint lib --max-warnings 0 && prettier lib --check",
     "test": "jest",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "webpack": "webpack"
   },
   "repository": "git@github.com:freeCodeCamp/curriculum-helpers.git",
   "jest": {

--- a/package.json
+++ b/package.json
@@ -11,8 +11,12 @@
   "files": [
     "/dist"
   ],
-  "main": "dist/",
-  "module": "dist/index.browser.js",
+  "exports": {
+    ".": {
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.mjs"
+    }
+  },
   "keywords": [
     ""
   ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,19 +1,13 @@
 const path = require("path");
 
 console.info("Building in " + process.env.NODE_ENV + " mode.");
-module.exports = {
-  mode: process.env.NODE_ENV ? "production" : "development",
+const baseConfig = {
+  mode: process.env.NODE_ENV,
   entry: {
     index: "./lib/index.ts",
   },
-  devtool: process.env.NODE_ENV ? "source-map" : "inline-source-map",
-  output: {
-    globalObject: 'this',
-    library: {
-      name: "helpers",
-      type: "umd",
-    },
-  },
+  devtool:
+    process.env.NODE_ENV === "production" ? "source-map" : "inline-source-map",
   module: {
     rules: [
       {
@@ -30,3 +24,33 @@ module.exports = {
     },
   },
 };
+
+const nodeConfig = {
+  ...baseConfig,
+  target: "node",
+  output: {
+    library: {
+      type: "umd",
+    },
+    filename: "index.node.js",
+    path: path.resolve(__dirname, "dist"),
+  },
+};
+
+const browserConfig = {
+  ...baseConfig,
+  target: "web",
+  experiments: {
+    outputModule: true,
+  },
+  output: {
+    library: {
+      type: "module",
+      // type: "commonjs-static",
+    },
+    filename: "index.browser.js",
+    path: path.resolve(__dirname, "dist"),
+  },
+};
+
+module.exports = [nodeConfig, browserConfig];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,9 +30,9 @@ const nodeConfig = {
   target: "node",
   output: {
     library: {
-      type: "umd",
+      type: "commonjs",
     },
-    filename: "index.node.js",
+    filename: "index.cjs",
     path: path.resolve(__dirname, "dist"),
   },
 };
@@ -48,7 +48,7 @@ const browserConfig = {
       type: "module",
       // type: "commonjs-static",
     },
-    filename: "index.browser.js",
+    filename: "index.mjs",
     path: path.resolve(__dirname, "dist"),
   },
 };


### PR DESCRIPTION
Tested like this:

```js
// index.js
import * as __helpers from "@freecodecamp/curriculum-helpers/dist/index.node.js";
console.log(__helpers);
```

```html
<!-- index.html -->
<!DOCTYPE html>
<html lang="en">
<head>
  <meta charset="UTF-8">
  <meta name="viewport" content="width=device-width, initial-scale=1.0">
  <title>Curriculum Helpers</title>
</head>
<body>
  <h1>Curriculum Helpers</h1>
</body>
<script type="module">
  import * as __helpers from "./node_modules/@freecodecamp/curriculum-helpers/dist/index.browser.js";
  console.log(__helpers);
</script>
</html>
```