### PR TITLE
docs: update css section

### DIFF
--- a/docs/css.md
+++ b/docs/css.md
@@ -287,6 +287,7 @@ describe("getStyle", () => {
     );
   });
 });
+
 describe("getStyleAny", () => {
   it("should return an ExtendedCSSStyleDeclartion object of length 1", () => {
     expect(tester.getStyleAny([".earth", ".sky"])?.length).toEqual(1);
@@ -295,6 +296,7 @@ describe("getStyleAny", () => {
     expect(tester.getStyleAny([".sun", ".earth", ".moon"])).toBeNull();
   });
 });
+
 describe("isPropertyUsed", () => {
   it("should return true on existing properties", () => {
     expect(tester.isPropertyUsed("height")).toBeTruthy();
@@ -303,11 +305,13 @@ describe("isPropertyUsed", () => {
     expect(tester.isPropertyUsed("--building-color1")).toBeTruthy();
   });
 });
+
 describe("isDeclaredAfter", () => {
   it("should return true if existing style is declared after another", () => {
     expect(tester.getStyleRule(".bb1a")?.isDeclaredAfter(".bb1")).toBeTruthy();
   });
 });
+
 describe("getPropertyValue", () => {
   it("should return custom property value needing trim", () => {
     expect(
@@ -320,16 +324,18 @@ describe("getPropertyValue", () => {
     ).toBeTruthy();
   });
   it("should return property value without evaluating result", () => {
-    expect(tester.getStyle(".bb4a")?.getPropertyValue("background-color")).toEqual(
-      "var(--building-color4)"
-    );
+    expect(
+      tester.getStyle(".bb4a")?.getPropertyValue("background-color")
+    ).toEqual("var(--building-color4)");
   });
 });
+
 describe("getCSSRules", () => {
   it("should return a CSSRules array of length 1", () => {
     expect(tester.getCSSRules("media")?.length).toEqual(1);
   });
 });
+
 describe("getRuleListsWithinMedia", () => {
   it("should return a CSSMediaRule array with a selectable CSSStyleRule", () => {
     expect(
@@ -355,6 +361,7 @@ describe("getRuleListsWithinMedia", () => {
     );
   });
 });
+
 describe("selectorsFromSelector", () => {
   it("should return an empty array", () => {
     setupDocument();

--- a/docs/css.md
+++ b/docs/css.md
@@ -272,7 +272,7 @@ body {
 ```
 ````
 
-```javascript,mdbook-runnable,hidelines=#
+```javascript
 const tester = new CSSHelp(document);
 describe("getStyle", () => {
   it("should return an ExtendedCSSStyleDeclartion object of length 1", () => {


### PR DESCRIPTION
- fix(docs): prevent CSS code from being executed
- refactor(docs): newlines around decribe blocks

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I was a little confused why this was acting like it was runnable when it wasn't, so I changed it. The newlines just make it a touch more readable imo.

<!-- Feel free to add any additional description of changes below this line -->
