### PR TITLE
fix: make types discoverable

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
       "default": "./dist/index.mjs"
     }
   },
+  "types": "./dist/index.d.ts",
   "keywords": [
     ""
   ],


### PR DESCRIPTION
They need to be declared in package.json in order for importing packages
to find them.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
