### PR TITLE
feat: more ast helpers: __str__ and find_body

### DIFF
--- a/docs/python.md
+++ b/docs/python.md
@@ -122,6 +122,25 @@ assert add(a, b) == 300
 In contrast to the regex-based helpers, these helpers need to be run in Python, not
 JavaScript
 
+### Formatting output
+
+`str` returns a string that would parse to the same AST as the node. For example:
+
+```python
+function_str = """
+def foo():
+  # will not be in the output
+  x = 1
+
+"""
+output_str = """
+def foo():
+    x = 1"""
+str(Node(function_str)) == output_str # True
+```
+
+The output and source string compile to the same AST, but the output is indented with 4 spaces. Comments and trailing whitespace are removed.
+
 ### Finding nodes
 
 `find_` functions search the current scope and return one of the following:
@@ -145,6 +164,15 @@ When the variable is out of scope, `find_variable` returns an `None` node (i.e. 
 
 ```python
 Node('def foo():\n  x = "1"').find_variable("x") == Node() # True
+```
+
+#### `find_body`
+
+```python
+func_str = """
+def foo():
+    x = 1"""
+Node(func_str).find_function("foo").find_body().is_equivalent("x = 1") # True
 ```
 
 #### `find_class`

--- a/python/py_helpers.py
+++ b/python/py_helpers.py
@@ -62,6 +62,13 @@ class Node:
                     return Node(node)
         return Node()
 
+    def find_body(self):
+        if not isinstance(self.tree, ast.AST):
+            return Node()
+        if not hasattr(self.tree, "body"):
+            return Node()
+        return Node(ast.Module(self.tree.body, []))
+
     # "has" functions return a boolean indicating whether whatever is being
     # searched for exists. In this case, it returns True if the variable exists.
 

--- a/python/py_helpers.py
+++ b/python/py_helpers.py
@@ -41,6 +41,11 @@ class Node:
             return "Node:\nNone"
         return "Node:\n" + ast.dump(self.tree, indent=2)
 
+    def __str__(self):
+        if self.tree == None:
+            return "# no ast"
+        return ast.unparse(self.tree)
+
     def _has_body(self):
         return bool(getattr(self.tree, "body", False))
 

--- a/python/py_helpers.test.py
+++ b/python/py_helpers.test.py
@@ -223,6 +223,37 @@ class Foo:
 
         self.assertFalse(node.has_function("bar"))
 
+    def test_find_body(self):
+        func_str = """def foo():
+  x = 1
+  print(x)
+"""
+        node = Node(func_str)
+
+        self.assertTrue(
+            node.find_function("foo").find_body().is_equivalent("x = 1\nprint(x)")
+        )
+        self.assertEqual("x = 1\nprint(x)", str(node.find_function("foo").find_body()))
+
+    def test_find_body_with_class(self):
+        class_str = """
+class Foo:
+  def __init__(self):
+    self.x = 1
+"""
+        node = Node(class_str)
+
+        self.assertTrue(
+            node.find_class("Foo")
+            .find_body()
+            .is_equivalent("def __init__(self):\n    self.x = 1")
+        )
+
+    def test_find_body_without_body(self):
+        node = Node("x = 1")
+
+        self.assertEqual(node.find_variable("x").find_body(), Node())
+
 
 class TestEquivalenceHelpers(unittest.TestCase):
     def test_is_equivalent(self):
@@ -490,6 +521,20 @@ if True:
 
     def test_none_str(self):
         self.assertEqual("# no ast", str(Node()))
+
+    def test_str_with_comments(self):
+        func_str = """def foo():
+  # comment
+  pass
+
+
+"""
+        # Note: comments are discarded
+        expected = """def foo():
+    pass"""
+
+        self.assertEqual(expected, str(Node(func_str)))
+
 
     def test_repr(self):
         func_str = """def foo():

--- a/python/py_helpers.test.py
+++ b/python/py_helpers.test.py
@@ -478,6 +478,27 @@ if True:
 
         self.assertEqual(len(node.find_ifs()), 2)
 
+    def test_str(self):
+        func_str = """def foo():
+  pass
+"""
+        # Note: the indentation and whitespace is not preserved.
+        expected = """def foo():
+    pass"""
+
+        self.assertEqual(expected, str(Node(func_str)))
+
+    def test_none_str(self):
+        self.assertEqual("# no ast", str(Node()))
+
+    def test_repr(self):
+        func_str = """def foo():
+  pass
+"""
+        node = Node(func_str)
+
+        self.assertEqual(repr(node), "Node:\n" + ast.dump(node.tree, indent=2))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

@ShaunSHamilton while working on https://github.com/freeCodeCamp/freeCodeCamp/pull/53125 I realised that it would be nice to simply get the code at certain points. Since `repr` gives you the AST dump, I figured `str` could give us the `unparse`d string.

<!-- Feel free to add any additional description of changes below this line -->
