### PR TITLE
fix: getDef: handle leading newline in body

### DIFF
--- a/lib/__tests__/python.test.ts
+++ b/lib/__tests__/python.test.ts
@@ -38,6 +38,26 @@ def c():
       expect(function_body).toEqual("  a = 2\n");
       expect(function_parameters).toEqual("d, e");
     });
+
+    it("handles indentation", () => {
+      const code = `
+    a = 1
+      
+    def b(d, e):
+      a = 2
+    `;
+      const match = python.getDef(code, "b");
+      expect(match).not.toBeNull();
+
+      const { def, function_indentation, function_body, function_parameters } =
+        match as FunctionMatch;
+      expect(def).toEqual(`    def b(d, e):
+      a = 2
+    `);
+      expect(function_indentation).toEqual(4);
+      expect(function_body).toEqual(`      a = 2\n    `);
+      expect(function_parameters).toEqual("d, e");
+    });
   });
 
   describe("removeComments", () => {

--- a/lib/__tests__/python.test.ts
+++ b/lib/__tests__/python.test.ts
@@ -58,6 +58,27 @@ def c():
       expect(function_body).toEqual(`      a = 2\n    `);
       expect(function_parameters).toEqual("d, e");
     });
+
+    it("handles whitespace after def", () => {
+      const code = `
+def b(d, e):
+
+  a = 2
+  `;
+      const match = python.getDef(code, "b");
+      expect(match).not.toBeNull();
+
+      const { def, function_indentation, function_body, function_parameters } =
+        match as FunctionMatch;
+      expect(def).toEqual(`def b(d, e):
+
+  a = 2
+  `);
+      expect(function_indentation).toEqual(0);
+      expect(function_body).toEqual(`  a = 2
+  `);
+      expect(function_parameters).toEqual("d, e");
+    });
   });
 
   describe("removeComments", () => {

--- a/lib/__tests__/python.test.ts
+++ b/lib/__tests__/python.test.ts
@@ -1,5 +1,18 @@
 import * as helper from "../index";
 
+type FunctionMatch = {
+  def: string;
+  function_indentation: number;
+  function_body: string;
+  function_parameters: string;
+};
+
+type BlockMatch = {
+  block_indentation: number;
+  block_body: string;
+  block_condition: string;
+};
+
 describe("python", () => {
   const { python } = helper;
   describe("getDef", () => {
@@ -14,20 +27,16 @@ def c():
   a = 1
 `;
       const match = python.getDef(code, "b");
-      if (match) {
-        const {
-          def,
-          function_indentation,
-          function_body,
-          function_parameters,
-        } = match;
-        expect(def).toEqual(`def b(d, e):
+      expect(match).not.toBeNull();
+
+      const { def, function_indentation, function_body, function_parameters } =
+        match as FunctionMatch;
+      expect(def).toEqual(`def b(d, e):
   a = 2
 `);
-        expect(function_indentation).toEqual(0);
-        expect(function_body).toEqual("  a = 2\n");
-        expect(function_parameters).toEqual("d, e");
-      }
+      expect(function_indentation).toEqual(0);
+      expect(function_body).toEqual("  a = 2\n");
+      expect(function_parameters).toEqual("d, e");
     });
   });
 
@@ -75,19 +84,18 @@ for i in range(10):
       ];
       for (const match of matches) {
         expect(match).not.toBeNull();
-        if (match) {
-          // eslint-disable-next-line camelcase
-          const { block_indentation, block_body, block_condition } = match;
-          expect(block_condition).toEqual("if a == 1");
-          expect(block_indentation).toEqual(0);
-          expect(block_body).toEqual(
-            `  a = 2
+        // eslint-disable-next-line camelcase
+        const { block_indentation, block_body, block_condition } =
+          match as BlockMatch;
+        expect(block_condition).toEqual("if a == 1");
+        expect(block_indentation).toEqual(0);
+        expect(block_body).toEqual(
+          `  a = 2
   b = 3
   if b == 3:
     a = 4
 `
-          );
-        }
+        );
       }
 
       const matches2 = [
@@ -98,14 +106,14 @@ for i in range(10):
       ];
       for (const match of matches2) {
         expect(match).not.toBeNull();
-        if (match) {
-          // eslint-disable-next-line camelcase
-          const { block_indentation, block_body, block_condition } = match;
-          expect(block_condition).toEqual("for i in range(10)");
-          expect(block_indentation).toEqual(0);
-          expect(block_body).toEqual(`  a = 1
+
+        // eslint-disable-next-line camelcase
+        const { block_indentation, block_body, block_condition } =
+          match as BlockMatch;
+        expect(block_condition).toEqual("for i in range(10)");
+        expect(block_indentation).toEqual(0);
+        expect(block_body).toEqual(`  a = 1
 `);
-        }
       }
     });
   });

--- a/lib/__tests__/python.test.ts
+++ b/lib/__tests__/python.test.ts
@@ -2,8 +2,9 @@ import * as helper from "../index";
 
 describe("python", () => {
   const { python } = helper;
-  it("getDef", () => {
-    const code = `
+  describe("getDef", () => {
+    it("finds function, body, indentation and params", () => {
+      const code = `
 a = 1
 
 def b(d, e):
@@ -12,21 +13,27 @@ def b(d, e):
 def c():
   a = 1
 `;
-    const match = python.getDef(code, "b");
-    if (match) {
-      const { def, function_indentation, function_body, function_parameters } =
-        match;
-      expect(def).toEqual(`def b(d, e):
+      const match = python.getDef(code, "b");
+      if (match) {
+        const {
+          def,
+          function_indentation,
+          function_body,
+          function_parameters,
+        } = match;
+        expect(def).toEqual(`def b(d, e):
   a = 2
 `);
-      expect(function_indentation).toEqual(0);
-      expect(function_body).toEqual("  a = 2\n");
-      expect(function_parameters).toEqual("d, e");
-    }
+        expect(function_indentation).toEqual(0);
+        expect(function_body).toEqual("  a = 2\n");
+        expect(function_parameters).toEqual("d, e");
+      }
+    });
   });
 
-  it("removeComments", () => {
-    const code = `
+  describe("removeComments", () => {
+    it("removes comments without removing whitespace", () => {
+      const code = `
 a = 1
 # comment
 def b(d, e):
@@ -34,8 +41,8 @@ def b(d, e):
   # comment
   return a #comment
 `;
-    const result = python.removeComments(code);
-    expect(result).toEqual(`
+      const result = python.removeComments(code);
+      expect(result).toEqual(`
 a = 1
 
 def b(d, e):
@@ -43,10 +50,12 @@ def b(d, e):
   
   return a 
 `);
+    });
   });
 
-  it("getBlock", () => {
-    const code = `
+  describe("getBlock", () => {
+    it("finds the body of an if statement", () => {
+      const code = `
 a = 1
 
 if a == 1:
@@ -58,45 +67,46 @@ if a == 1:
 for i in range(10):
   a = 1
 `;
-    const matches = [
-      python.getBlock(code, "if a == 1"),
-      python.getBlock(code, /if +\w+ *== *\d+/),
-      // eslint-disable-next-line prefer-regex-literals
-      python.getBlock(code, new RegExp("if +\\w+ *== *\\d+")),
-    ];
-    for (const match of matches) {
-      expect(match).not.toBeNull();
-      if (match) {
-        // eslint-disable-next-line camelcase
-        const { block_indentation, block_body, block_condition } = match;
-        expect(block_condition).toEqual("if a == 1");
-        expect(block_indentation).toEqual(0);
-        expect(block_body).toEqual(
-          `  a = 2
+      const matches = [
+        python.getBlock(code, "if a == 1"),
+        python.getBlock(code, /if +\w+ *== *\d+/),
+        // eslint-disable-next-line prefer-regex-literals
+        python.getBlock(code, new RegExp("if +\\w+ *== *\\d+")),
+      ];
+      for (const match of matches) {
+        expect(match).not.toBeNull();
+        if (match) {
+          // eslint-disable-next-line camelcase
+          const { block_indentation, block_body, block_condition } = match;
+          expect(block_condition).toEqual("if a == 1");
+          expect(block_indentation).toEqual(0);
+          expect(block_body).toEqual(
+            `  a = 2
   b = 3
   if b == 3:
     a = 4
 `
-        );
+          );
+        }
       }
-    }
 
-    const matches2 = [
-      python.getBlock(code, "for i in range(10)"),
-      python.getBlock(code, /for +\w+ +in +range\(\d+\)/),
-      // eslint-disable-next-line prefer-regex-literals
-      python.getBlock(code, new RegExp("for +\\w+ +in +range\\(\\d+\\)")),
-    ];
-    for (const match of matches2) {
-      expect(match).not.toBeNull();
-      if (match) {
-        // eslint-disable-next-line camelcase
-        const { block_indentation, block_body, block_condition } = match;
-        expect(block_condition).toEqual("for i in range(10)");
-        expect(block_indentation).toEqual(0);
-        expect(block_body).toEqual(`  a = 1
+      const matches2 = [
+        python.getBlock(code, "for i in range(10)"),
+        python.getBlock(code, /for +\w+ +in +range\(\d+\)/),
+        // eslint-disable-next-line prefer-regex-literals
+        python.getBlock(code, new RegExp("for +\\w+ +in +range\\(\\d+\\)")),
+      ];
+      for (const match of matches2) {
+        expect(match).not.toBeNull();
+        if (match) {
+          // eslint-disable-next-line camelcase
+          const { block_indentation, block_body, block_condition } = match;
+          expect(block_condition).toEqual("for i in range(10)");
+          expect(block_indentation).toEqual(0);
+          expect(block_body).toEqual(`  a = 1
 `);
+        }
       }
-    }
+    });
   });
 });

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -101,7 +101,7 @@ export const python = {
   astHelpers,
   getDef(code: string, functionName: string) {
     const regex = new RegExp(
-      `\\n?(?<function_indentation> *?)def +${functionName} *\\((?<function_parameters>[^\\)]*)\\)\\s*: *?\\n(?<function_body> +.*?)(?=\\n\\k<function_indentation>[\\w#]|$)`,
+      `\\n?(?<function_indentation> *?)def +${functionName} *\\((?<function_parameters>[^\\)]*)\\)\\s*:\\s*?\\n(?<function_body> +.*?)(?=\\n\\k<function_indentation>[\\w#]|$)`,
       "s"
     );
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

@ShaunSHamilton I did a little spring cleaning of the tests on the way, but the fix itself was just allowing `\s` after `def:` instead of just ` `. 

As far as I can see there aren't weird side effects, but regex is not my strong suit. All the curriculum tests pass, though, so I think it's okay.

<!-- Feel free to add any additional description of changes below this line -->
