### PR TITLE
feat: add helper for matching function strings

### DIFF
--- a/docs/curriculum-helpers.md
+++ b/docs/curriculum-helpers.md
@@ -9,3 +9,14 @@ const regex1 = /a\s/;
 const regex2 = /b/;
 concatRegex(regex1, regex2).source === "a\\sb";
 ```
+
+## functionRegexString
+
+Given a function name and, optionally, a list of parameters, returns a regex string that can be used to match that function declaration in a code block.
+
+```javascript
+let regex = functionRegexString("foo", ["bar", "baz"]);
+regex.test("function foo(bar, baz){}"); // => true
+regex.test("function foo(bar, baz, qux){}"); // => false
+regex.test("foo = (bar, baz) => {}"); // => true
+```

--- a/docs/curriculum-helpers.md
+++ b/docs/curriculum-helpers.md
@@ -12,13 +12,13 @@ concatRegex(regex1, regex2).source === "a\\sb";
 
 ## functionRegex
 
-Given a function name and, optionally, a list of parameters, returns a regex string that can be used to match that function declaration in a code block.
+Given a function name and, optionally, a list of parameters, returns a regex that can be used to match that function declaration in a code block.
 
 ```javascript
-let regex = new RegExp(functionRegex("foo", ["bar", "baz"]));
-regex.test("function foo(bar, baz){}"); // => true
-regex.test("function foo(bar, baz, qux){}"); // => false
-regex.test("foo = (bar, baz) => {}"); // => true
+let regex = functionRegex("foo", ["bar", "baz"]);
+regex.test("function foo(bar, baz){}"); // true
+regex.test("function foo(bar, baz, qux){}"); // false
+regex.test("foo = (bar, baz) => {}"); // true
 ```
 
 ### Options
@@ -26,8 +26,20 @@ regex.test("foo = (bar, baz) => {}"); // => true
 - capture: boolean - If true, the regex will capture the function definition, including it's body, otherwise not. Defaults to false.
 
 ```javascript
-let regex = functionRegex("foo", ["bar", "baz"], { capture: true });
-let match = `\\ other stuff;
+let regEx = functionRegex("foo", ["bar", "baz"], { capture: true });
+let combinedRegEx = concatRegex(/var x = "y"; /, regEx);
+
+let match = `var x = "y";
 function foo(bar, baz){}`.match(regex);
-match[1]; // => 'function foo(bar, baz){}'
+match[1]; // "function foo(bar, baz){}"
+// i.e. only the function definition is captured
+```
+
+NOTE: capture does not work properly with arrow functions. It will capture text after the function body, too.
+
+```javascript
+let regEx = functionRegex("myFunc", ["arg1"], { capture: true });
+
+let match = "myFunc = arg1 => arg1; console.log();\n // captured, unfortunately".match(regEx);
+match[1] // "myFunc = arg1 => arg1; console.log();\n // captured, unfortunately"
 ```

--- a/docs/curriculum-helpers.md
+++ b/docs/curriculum-helpers.md
@@ -24,6 +24,7 @@ regex.test("foo = (bar, baz) => {}"); // true
 ### Options
 
 - capture: boolean - If true, the regex will capture the function definition, including it's body, otherwise not. Defaults to false.
+- includeBody: boolean - If true, the regex will include the function body in the match. Otherwise it will stop at the first bracket. Defaults to true.
 
 ```javascript
 let regEx = functionRegex("foo", ["bar", "baz"], { capture: true });
@@ -33,6 +34,13 @@ let match = `var x = "y";
 function foo(bar, baz){}`.match(regex);
 match[1]; // "function foo(bar, baz){}"
 // i.e. only the function definition is captured
+```
+
+```javascript
+let regEx = functionRegex("foo", ["bar", "baz"], { includeBody: false });
+
+let match = `function foo(bar, baz){console.log('ignored')}`.match(regex);
+match[1]; // "function foo(bar, baz){"
 ```
 
 NOTE: capture does not work properly with arrow functions. It will capture text after the function body, too.

--- a/docs/curriculum-helpers.md
+++ b/docs/curriculum-helpers.md
@@ -15,8 +15,19 @@ concatRegex(regex1, regex2).source === "a\\sb";
 Given a function name and, optionally, a list of parameters, returns a regex string that can be used to match that function declaration in a code block.
 
 ```javascript
-let regex = functionRegexString("foo", ["bar", "baz"]);
-regex.test("function foo(bar, baz){}"); // => true
-regex.test("function foo(bar, baz, qux){}"); // => false
-regex.test("foo = (bar, baz) => {}"); // => true
+let regex = new RegExp(functionRegexString('foo', ['bar', 'baz']));
+regex.test('function foo(bar, baz){}'); // => true
+regex.test('function foo(bar, baz, qux){}'); // => false
+regex.test('foo = (bar, baz) => {}'); // => true
+```
+
+### Options
+
+- capture: boolean - If true, the regex will capture the function definition, including it's body, otherwise not. Defaults to false.
+
+```javascript
+let regex = functionRegexString('foo', ['bar', 'baz'], {capture: true});
+let match = `\\ other stuff;
+function foo(bar, baz){}`.match(regex);
+match[1]; // => 'function foo(bar, baz){}'
 ```

--- a/docs/curriculum-helpers.md
+++ b/docs/curriculum-helpers.md
@@ -10,15 +10,15 @@ const regex2 = /b/;
 concatRegex(regex1, regex2).source === "a\\sb";
 ```
 
-## functionRegexString
+## functionRegex
 
 Given a function name and, optionally, a list of parameters, returns a regex string that can be used to match that function declaration in a code block.
 
 ```javascript
-let regex = new RegExp(functionRegexString('foo', ['bar', 'baz']));
-regex.test('function foo(bar, baz){}'); // => true
-regex.test('function foo(bar, baz, qux){}'); // => false
-regex.test('foo = (bar, baz) => {}'); // => true
+let regex = new RegExp(functionRegex("foo", ["bar", "baz"]));
+regex.test("function foo(bar, baz){}"); // => true
+regex.test("function foo(bar, baz, qux){}"); // => false
+regex.test("foo = (bar, baz) => {}"); // => true
 ```
 
 ### Options
@@ -26,7 +26,7 @@ regex.test('foo = (bar, baz) => {}'); // => true
 - capture: boolean - If true, the regex will capture the function definition, including it's body, otherwise not. Defaults to false.
 
 ```javascript
-let regex = functionRegexString('foo', ['bar', 'baz'], {capture: true});
+let regex = functionRegex("foo", ["bar", "baz"], { capture: true });
 let match = `\\ other stuff;
 function foo(bar, baz){}`.match(regex);
 match[1]; // => 'function foo(bar, baz){}'

--- a/lib/__tests__/curriculum-helper.test.ts
+++ b/lib/__tests__/curriculum-helper.test.ts
@@ -150,28 +150,28 @@ describe("concatRegex", () => {
   });
 });
 
-describe("functionRegexString", () => {
-  const { functionRegexString } = helper;
+describe("functionRegex", () => {
+  const { functionRegex } = helper;
   it("returns a string", () => {
-    expect(typeof functionRegexString("myFunc")).toBe("string");
+    expect(typeof functionRegex("myFunc")).toBe("string");
   });
 
   describe("when compiled into a regular expression", () => {
     it("matches the named function", () => {
       const funcName = "myFunc";
-      const regEx = new RegExp(functionRegexString(funcName));
+      const regEx = new RegExp(functionRegex(funcName));
       expect(regEx.test("function myFunc(){}")).toBe(true);
     });
 
     it("does not match a different named function", () => {
       const funcName = "myFunc";
-      const regEx = new RegExp(functionRegexString(funcName));
+      const regEx = new RegExp(functionRegex(funcName));
       expect(regEx.test("function notMyFunc(){}")).toBe(false);
     });
 
     it("matches the named function with arguments and a body", () => {
       const funcName = "myFunc";
-      const regEx = new RegExp(functionRegexString(funcName, ["arg1", "arg2"]));
+      const regEx = new RegExp(functionRegex(funcName, ["arg1", "arg2"]));
       expect(
         regEx.test("function myFunc(arg1, arg2){\n console.log()\n}")
       ).toBe(true);
@@ -179,41 +179,41 @@ describe("functionRegexString", () => {
 
     it("does not match the named function with different arguments", () => {
       const funcName = "myFunc";
-      const regEx = new RegExp(functionRegexString(funcName, ["arg1", "arg2"]));
+      const regEx = new RegExp(functionRegex(funcName, ["arg1", "arg2"]));
       expect(regEx.test("function myFunc(arg1, arg3){}")).toBe(false);
     });
 
     it("matches arrow functions", () => {
       const funcName = "myFunc";
-      const regEx = new RegExp(functionRegexString(funcName, ["arg1", "arg2"]));
+      const regEx = new RegExp(functionRegex(funcName, ["arg1", "arg2"]));
       expect(regEx.test("myFunc = (arg1, arg2) => {}")).toBe(true);
     });
 
     it("matches arrow functions without brackets", () => {
       const funcName = "myFunc";
-      const regEx = new RegExp(functionRegexString(funcName, ["arg1"]));
+      const regEx = new RegExp(functionRegex(funcName, ["arg1"]));
       expect(regEx.test("myFunc = arg1 => arg1 + 1")).toBe(true);
     });
 
     it("matches a function with a special character in the name", () => {
       const funcName = "myFunc$";
-      const regEx = new RegExp(functionRegexString(funcName));
+      const regEx = new RegExp(functionRegex(funcName));
       expect(regEx.test("function myFunc$(){}")).toBe(true);
     });
 
     it("matches anonymous functions", () => {
-      const regEx = new RegExp(functionRegexString(null, ["arg1", "arg2"]));
+      const regEx = new RegExp(functionRegex(null, ["arg1", "arg2"]));
       expect(regEx.test("function(arg1, arg2) {}")).toBe(true);
     });
 
     it("matches anonymous arrow functions", () => {
-      const regEx = new RegExp(functionRegexString(null, ["arg1", "arg2"]));
+      const regEx = new RegExp(functionRegex(null, ["arg1", "arg2"]));
       expect(regEx.test("(arg1, arg2) => {}")).toBe(true);
     });
 
     it("ignores irrelevant whitespace", () => {
       const funcName = "myFunc";
-      const regEx = new RegExp(functionRegexString(funcName, ["arg1", "arg2"]));
+      const regEx = new RegExp(functionRegex(funcName, ["arg1", "arg2"]));
       expect(regEx.test("function \n\n myFunc \n ( arg1 , arg2 ) \n{ }")).toBe(
         true
       );
@@ -222,7 +222,7 @@ describe("functionRegexString", () => {
     it("can be easily combined with other regex", () => {
       const funcName = "myFunc";
       const regEx = new RegExp(
-        `let x = ${functionRegexString(funcName)}; console\\.log\\(x\\);`
+        `let x = ${functionRegex(funcName)}; console\\.log\\(x\\);`
       );
 
       expect(regEx.test("function myFunc(){}")).toBe(false);

--- a/lib/__tests__/curriculum-helper.test.ts
+++ b/lib/__tests__/curriculum-helper.test.ts
@@ -129,28 +129,49 @@ describe("concatRegex", () => {
   });
 });
 
-describe("functionRegExString", () => {
-  const { functionRegExString } = helper;
+describe("concatRegex", () => {
+  it("returns a Regex", () => {
+    const { concatRegex } = helper;
+    expect(concatRegex(/a/, /b/)).toBeInstanceOf(RegExp);
+    expect(concatRegex(/a/, "b")).toBeInstanceOf(RegExp);
+  });
+
+  it("returns a compiled regex, when given a string or regex", () => {
+    const { concatRegex } = helper;
+
+    expect(concatRegex("ab").source).toBe("ab");
+    expect(concatRegex(/\s/).source).toBe("\\s");
+  });
+
+  it("concatenates two regexes", () => {
+    const { concatRegex } = helper;
+    const regEx = concatRegex(/.*/, /b\s/);
+    expect(regEx.source).toBe(".*b\\s");
+  });
+});
+
+describe("functionRegexString", () => {
+  const { functionRegexString } = helper;
   it("returns a string", () => {
-    expect(typeof functionRegExString("myFunc")).toBe("string");
+    expect(typeof functionRegexString("myFunc")).toBe("string");
   });
 
   describe("when compiled into a regular expression", () => {
     it("matches the named function", () => {
       const funcName = "myFunc";
-      const regEx = new RegExp(functionRegExString(funcName));
+      const regEx = new RegExp(functionRegexString(funcName));
       expect(regEx.test("function myFunc(){}")).toBe(true);
     });
 
     it("does not match a different named function", () => {
       const funcName = "myFunc";
-      const regEx = new RegExp(functionRegExString(funcName));
+      const regEx = new RegExp(functionRegexString(funcName));
       expect(regEx.test("function notMyFunc(){}")).toBe(false);
     });
 
     it("matches the named function with arguments and a body", () => {
       const funcName = "myFunc";
-      const regEx = new RegExp(functionRegExString(funcName, ["arg1", "arg2"]));
+      const regEx = new RegExp(functionRegexString(funcName, ["arg1", "arg2"]));
       expect(
         regEx.test("function myFunc(arg1, arg2){\n console.log()\n}")
       ).toBe(true);
@@ -158,41 +179,41 @@ describe("functionRegExString", () => {
 
     it("does not match the named function with different arguments", () => {
       const funcName = "myFunc";
-      const regEx = new RegExp(functionRegExString(funcName, ["arg1", "arg2"]));
+      const regEx = new RegExp(functionRegexString(funcName, ["arg1", "arg2"]));
       expect(regEx.test("function myFunc(arg1, arg3){}")).toBe(false);
     });
 
     it("matches arrow functions", () => {
       const funcName = "myFunc";
-      const regEx = new RegExp(functionRegExString(funcName, ["arg1", "arg2"]));
+      const regEx = new RegExp(functionRegexString(funcName, ["arg1", "arg2"]));
       expect(regEx.test("myFunc = (arg1, arg2) => {}")).toBe(true);
     });
 
     it("matches arrow functions without brackets", () => {
       const funcName = "myFunc";
-      const regEx = new RegExp(functionRegExString(funcName, ["arg1"]));
+      const regEx = new RegExp(functionRegexString(funcName, ["arg1"]));
       expect(regEx.test("myFunc = arg1 => arg1 + 1")).toBe(true);
     });
 
     it("matches a function with a special character in the name", () => {
       const funcName = "myFunc$";
-      const regEx = new RegExp(functionRegExString(funcName));
+      const regEx = new RegExp(functionRegexString(funcName));
       expect(regEx.test("function myFunc$(){}")).toBe(true);
     });
 
     it("matches anonymous functions", () => {
-      const regEx = new RegExp(functionRegExString(null, ["arg1", "arg2"]));
+      const regEx = new RegExp(functionRegexString(null, ["arg1", "arg2"]));
       expect(regEx.test("function(arg1, arg2) {}")).toBe(true);
     });
 
     it("matches anonymous arrow functions", () => {
-      const regEx = new RegExp(functionRegExString(null, ["arg1", "arg2"]));
+      const regEx = new RegExp(functionRegexString(null, ["arg1", "arg2"]));
       expect(regEx.test("(arg1, arg2) => {}")).toBe(true);
     });
 
     it("ignores irrelevant whitespace", () => {
       const funcName = "myFunc";
-      const regEx = new RegExp(functionRegExString(funcName, ["arg1", "arg2"]));
+      const regEx = new RegExp(functionRegexString(funcName, ["arg1", "arg2"]));
       expect(regEx.test("function \n\n myFunc \n ( arg1 , arg2 ) \n{ }")).toBe(
         true
       );
@@ -201,7 +222,7 @@ describe("functionRegExString", () => {
     it("can be easily combined with other regex", () => {
       const funcName = "myFunc";
       const regEx = new RegExp(
-        `let x = ${functionRegExString(funcName)}; console\\.log\\(x\\);`
+        `let x = ${functionRegexString(funcName)}; console\\.log\\(x\\);`
       );
 
       expect(regEx.test("function myFunc(){}")).toBe(false);
@@ -218,14 +239,14 @@ describe("functionRegExString", () => {
     it("can optionally capture the function", () => {
       const funcName = "myFunc";
       const regEx = new RegExp(
-        functionRegExString(funcName, ["arg1", "arg2"], { capture: true })
+        functionRegexString(funcName, ["arg1", "arg2"], { capture: true })
       );
       const match = "var x = 'y'; function myFunc(arg1, arg2){}".match(regEx);
       expect(match).not.toBeNull();
       expect(match![1]).toBe("function myFunc(arg1, arg2){}");
 
       const nonCapturingRegEx = new RegExp(
-        functionRegExString(funcName, ["arg1", "arg2"])
+        functionRegexString(funcName, ["arg1", "arg2"])
       );
       const nonCapturingMatch = "function myFunc(arg1, arg2){}".match(
         nonCapturingRegEx
@@ -237,7 +258,7 @@ describe("functionRegExString", () => {
     it("can capture arrow functions", () => {
       const funcName = "myFunc";
       const regEx = new RegExp(
-        functionRegExString(funcName, ["arg1", "arg2"], { capture: true })
+        functionRegexString(funcName, ["arg1", "arg2"], { capture: true })
       );
       const match = "myFunc = (arg1, arg2) => {return arg1 + arg2}".match(
         regEx
@@ -249,7 +270,7 @@ describe("functionRegExString", () => {
     it("can capture functions without brackets", () => {
       const funcName = "myFunc";
       const regEx = new RegExp(
-        functionRegExString(funcName, ["arg1"], { capture: true })
+        functionRegexString(funcName, ["arg1"], { capture: true })
       );
       const match = "myFunc = arg1 => arg1; console.log".match(regEx);
       expect(match).not.toBeNull();

--- a/lib/__tests__/curriculum-helper.test.ts
+++ b/lib/__tests__/curriculum-helper.test.ts
@@ -254,7 +254,7 @@ describe("functionRegex", () => {
     const code = `const naomi = (love) => {
   return love ** 2
 }`;
-    const startRE = functionRegex("naomi", ["love"], { closed: false });
+    const startRE = functionRegex("naomi", ["love"], { includeBody: false });
     const endRE = /\s*return\s*love\s*\*\*\s*2\s*\}/;
     const fullRE = helper.concatRegex(startRE, endRE);
 
@@ -269,7 +269,7 @@ describe("functionRegex", () => {
     const code = `function naomi(love) {
   return love ** 2
 }`;
-    const startRE = functionRegex("naomi", ["love"], { closed: false });
+    const startRE = functionRegex("naomi", ["love"], { includeBody: false });
     const endRE = /\s*return\s*love\s*\*\*\s*2\s\}/;
     const fullRE = helper.concatRegex(startRE, endRE);
 
@@ -284,7 +284,7 @@ describe("functionRegex", () => {
     const funcName = "myFunc";
     const regEx = functionRegex(funcName, ["arg1", "arg2"], {
       capture: true,
-      closed: false,
+      includeBody: false,
     });
     const combinedRegEx = helper.concatRegex(/var x = 'y'; /, regEx);
 
@@ -300,7 +300,7 @@ describe("functionRegex", () => {
     const funcName = "myFunc";
     const regEx = functionRegex(funcName, ["arg1", "arg2"], {
       capture: true,
-      closed: false,
+      includeBody: false,
     });
     const combinedRegEx = helper.concatRegex(/var x = 'y'; /, regEx);
 
@@ -316,7 +316,7 @@ describe("functionRegex", () => {
   it("ignores the body if there are no brackets and it's asked for the closed body", () => {
     const code = `const naomi = (love) => 2 * love;`;
     const funcRE = functionRegex("naomi", ["love"], {
-      closed: false,
+      includeBody: false,
     });
 
     expect(funcRE.test(code)).toBe(true);

--- a/lib/__tests__/curriculum-helper.test.ts
+++ b/lib/__tests__/curriculum-helper.test.ts
@@ -242,4 +242,37 @@ describe("functionRegex", () => {
       "myFunc = arg1 => arg1; console.log()\n // captured, unfortunately"
     );
   });
+
+  it("can match just up to the opening bracket for an arrow function", () => {
+    const code = `const naomi = (love) => {
+  return love ** 2
+}`;
+    const startRE = functionRegex("naomi", ["love"], { closed: false });
+    const endRE = /\s*return\s*love\s*\*\*\s*2\)/;
+    const fullRE = helper.concatRegex(startRE, endRE);
+
+    expect(startRE.test(code)).toBe(true);
+    expect(code.match(startRE)![0]).toBe("naomi = (love) => {");
+
+    expect(fullRE.test(code)).toBe(true);
+    expect(code.match(fullRE)![0]).toBe(code);
+  });
+
+  it("can match just up to the opening bracket for a function declaration", () => {
+    const code = `function naomi(love) {
+  return love ** 2
+}`;
+    const startRE = functionRegex("naomi", ["love"], { closed: false });
+    const endRE = /\s*return\s*love\s*\*\*\s*2\s\}/;
+    const fullRE = helper.concatRegex(startRE, endRE);
+
+    console.log(startRE);
+    console.log(fullRE);
+
+    expect(startRE.test(code)).toBe(true);
+    expect(code.match(startRE)![0]).toBe("function naomi(love) {");
+
+    expect(fullRE.test(code)).toBe(true);
+    expect(code.match(fullRE)![0]).toBe(code);
+  });
 });

--- a/lib/__tests__/curriculum-helper.test.ts
+++ b/lib/__tests__/curriculum-helper.test.ts
@@ -152,88 +152,84 @@ describe("concatRegex", () => {
 
 describe("functionRegex", () => {
   const { functionRegex } = helper;
-  it("returns a string", () => {
-    expect(typeof functionRegex("myFunc")).toBe("string");
+  it("returns a regex", () => {
+    expect(functionRegex("myFunc")).toBeInstanceOf(RegExp);
   });
 
-  describe("when compiled into a regular expression", () => {
-    it("matches the named function", () => {
-      const funcName = "myFunc";
-      const regEx = new RegExp(functionRegex(funcName));
-      expect(regEx.test("function myFunc(){}")).toBe(true);
-    });
+  it("matches the named function", () => {
+    const funcName = "myFunc";
+    const regEx = new RegExp(functionRegex(funcName));
+    expect(regEx.test("function myFunc(){}")).toBe(true);
+  });
 
-    it("does not match a different named function", () => {
-      const funcName = "myFunc";
-      const regEx = new RegExp(functionRegex(funcName));
-      expect(regEx.test("function notMyFunc(){}")).toBe(false);
-    });
+  it("does not match a different named function", () => {
+    const funcName = "myFunc";
+    const regEx = new RegExp(functionRegex(funcName));
+    expect(regEx.test("function notMyFunc(){}")).toBe(false);
+  });
 
-    it("matches the named function with arguments and a body", () => {
-      const funcName = "myFunc";
-      const regEx = new RegExp(functionRegex(funcName, ["arg1", "arg2"]));
-      expect(
-        regEx.test("function myFunc(arg1, arg2){\n console.log()\n}")
-      ).toBe(true);
-    });
+  it("matches the named function with arguments and a body", () => {
+    const funcName = "myFunc";
+    const regEx = new RegExp(functionRegex(funcName, ["arg1", "arg2"]));
+    expect(regEx.test("function myFunc(arg1, arg2){\n console.log()\n}")).toBe(
+      true
+    );
+  });
 
-    it("does not match the named function with different arguments", () => {
-      const funcName = "myFunc";
-      const regEx = new RegExp(functionRegex(funcName, ["arg1", "arg2"]));
-      expect(regEx.test("function myFunc(arg1, arg3){}")).toBe(false);
-    });
+  it("does not match the named function with different arguments", () => {
+    const funcName = "myFunc";
+    const regEx = new RegExp(functionRegex(funcName, ["arg1", "arg2"]));
+    expect(regEx.test("function myFunc(arg1, arg3){}")).toBe(false);
+  });
 
-    it("matches arrow functions", () => {
-      const funcName = "myFunc";
-      const regEx = new RegExp(functionRegex(funcName, ["arg1", "arg2"]));
-      expect(regEx.test("myFunc = (arg1, arg2) => {}")).toBe(true);
-    });
+  it("matches arrow functions", () => {
+    const funcName = "myFunc";
+    const regEx = new RegExp(functionRegex(funcName, ["arg1", "arg2"]));
+    expect(regEx.test("myFunc = (arg1, arg2) => {}")).toBe(true);
+  });
 
-    it("matches arrow functions without brackets", () => {
-      const funcName = "myFunc";
-      const regEx = new RegExp(functionRegex(funcName, ["arg1"]));
-      expect(regEx.test("myFunc = arg1 => arg1 + 1")).toBe(true);
-    });
+  it("matches arrow functions without brackets", () => {
+    const funcName = "myFunc";
+    const regEx = new RegExp(functionRegex(funcName, ["arg1"]));
+    expect(regEx.test("myFunc = arg1 => arg1 + 1")).toBe(true);
+  });
 
-    it("matches a function with a special character in the name", () => {
-      const funcName = "myFunc$";
-      const regEx = new RegExp(functionRegex(funcName));
-      expect(regEx.test("function myFunc$(){}")).toBe(true);
-    });
+  it("matches a function with a special character in the name", () => {
+    const funcName = "myFunc$";
+    const regEx = new RegExp(functionRegex(funcName));
+    expect(regEx.test("function myFunc$(){}")).toBe(true);
+  });
 
-    it("matches anonymous functions", () => {
-      const regEx = new RegExp(functionRegex(null, ["arg1", "arg2"]));
-      expect(regEx.test("function(arg1, arg2) {}")).toBe(true);
-    });
+  it("matches anonymous functions", () => {
+    const regEx = new RegExp(functionRegex(null, ["arg1", "arg2"]));
+    expect(regEx.test("function(arg1, arg2) {}")).toBe(true);
+  });
 
-    it("matches anonymous arrow functions", () => {
-      const regEx = new RegExp(functionRegex(null, ["arg1", "arg2"]));
-      expect(regEx.test("(arg1, arg2) => {}")).toBe(true);
-    });
+  it("matches anonymous arrow functions", () => {
+    const regEx = new RegExp(functionRegex(null, ["arg1", "arg2"]));
+    expect(regEx.test("(arg1, arg2) => {}")).toBe(true);
+  });
 
-    it("ignores irrelevant whitespace", () => {
-      const funcName = "myFunc";
-      const regEx = new RegExp(functionRegex(funcName, ["arg1", "arg2"]));
-      expect(regEx.test("function \n\n myFunc \n ( arg1 , arg2 ) \n{ }")).toBe(
-        true
-      );
-    });
+  it("ignores irrelevant whitespace", () => {
+    const funcName = "myFunc";
+    const regEx = new RegExp(functionRegex(funcName, ["arg1", "arg2"]));
+    expect(regEx.test("function \n\n myFunc \n ( arg1 , arg2 ) \n{ }")).toBe(
+      true
+    );
+  });
 
-    it("can be easily combined with other regex", () => {
-      const funcName = "myFunc";
-      const regEx = new RegExp(
-        `let x = ${functionRegex(funcName)}; console\\.log\\(x\\);`
-      );
+  it("can be easily combined with other regex", () => {
+    const funcName = "myFunc";
+    const regEx = new RegExp(
+      `let x = ${functionRegex(funcName).source}; console\\.log\\(x\\);`
+    );
 
-      expect(regEx.test("function myFunc(){}")).toBe(false);
-      expect(regEx.test("let x = myFunc = () => {};")).toBe(false);
-      expect(regEx.test("let x = function myFunc(){}")).toBe(false);
-      expect(regEx.test("let x = myFunc = () => {}; console.log(x);")).toBe(
-        true
-      );
-      expect(regEx.test("let x = function myFunc(){}; console.log(x);")).toBe(
-        true
-      );
-    });
+    expect(regEx.test("function myFunc(){}")).toBe(false);
+    expect(regEx.test("let x = myFunc = () => {};")).toBe(false);
+    expect(regEx.test("let x = function myFunc(){}")).toBe(false);
+    expect(regEx.test("let x = myFunc = () => {}; console.log(x);")).toBe(true);
+    expect(regEx.test("let x = function myFunc(){}; console.log(x);")).toBe(
+      true
+    );
   });
 });

--- a/lib/__tests__/curriculum-helper.test.ts
+++ b/lib/__tests__/curriculum-helper.test.ts
@@ -217,19 +217,4 @@ describe("functionRegex", () => {
       true
     );
   });
-
-  it("can be easily combined with other regex", () => {
-    const funcName = "myFunc";
-    const regEx = new RegExp(
-      `let x = ${functionRegex(funcName).source}; console\\.log\\(x\\);`
-    );
-
-    expect(regEx.test("function myFunc(){}")).toBe(false);
-    expect(regEx.test("let x = myFunc = () => {};")).toBe(false);
-    expect(regEx.test("let x = function myFunc(){}")).toBe(false);
-    expect(regEx.test("let x = myFunc = () => {}; console.log(x);")).toBe(true);
-    expect(regEx.test("let x = function myFunc(){}; console.log(x);")).toBe(
-      true
-    );
-  });
 });

--- a/lib/__tests__/curriculum-helper.test.ts
+++ b/lib/__tests__/curriculum-helper.test.ts
@@ -235,48 +235,5 @@ describe("functionRegexString", () => {
         true
       );
     });
-
-    it("can optionally capture the function", () => {
-      const funcName = "myFunc";
-      const regEx = new RegExp(
-        functionRegexString(funcName, ["arg1", "arg2"], { capture: true })
-      );
-      const match = "var x = 'y'; function myFunc(arg1, arg2){}".match(regEx);
-      expect(match).not.toBeNull();
-      expect(match![1]).toBe("function myFunc(arg1, arg2){}");
-
-      const nonCapturingRegEx = new RegExp(
-        functionRegexString(funcName, ["arg1", "arg2"])
-      );
-      const nonCapturingMatch = "function myFunc(arg1, arg2){}".match(
-        nonCapturingRegEx
-      );
-      expect(nonCapturingMatch).not.toBeNull();
-      expect(nonCapturingMatch![1]).toBeUndefined();
-    });
-
-    it("can capture arrow functions", () => {
-      const funcName = "myFunc";
-      const regEx = new RegExp(
-        functionRegexString(funcName, ["arg1", "arg2"], { capture: true })
-      );
-      const match = "myFunc = (arg1, arg2) => {return arg1 + arg2}".match(
-        regEx
-      );
-      expect(match).not.toBeNull();
-      expect(match![1]).toBe("myFunc = (arg1, arg2) => {return arg1 + arg2}");
-    });
-
-    it("can capture functions without brackets", () => {
-      const funcName = "myFunc";
-      const regEx = new RegExp(
-        functionRegexString(funcName, ["arg1"], { capture: true })
-      );
-      const match = "myFunc = arg1 => arg1; console.log".match(regEx);
-      expect(match).not.toBeNull();
-      // It's a greedy match, since it doesn't know where the function ends.
-      // This should be fine for most use cases.
-      expect(match![1]).toBe("myFunc = arg1 => arg1; console.log");
-    });
   });
 });

--- a/lib/__tests__/curriculum-helper.test.ts
+++ b/lib/__tests__/curriculum-helper.test.ts
@@ -129,27 +129,6 @@ describe("concatRegex", () => {
   });
 });
 
-describe("concatRegex", () => {
-  it("returns a Regex", () => {
-    const { concatRegex } = helper;
-    expect(concatRegex(/a/, /b/)).toBeInstanceOf(RegExp);
-    expect(concatRegex(/a/, "b")).toBeInstanceOf(RegExp);
-  });
-
-  it("returns a compiled regex, when given a string or regex", () => {
-    const { concatRegex } = helper;
-
-    expect(concatRegex("ab").source).toBe("ab");
-    expect(concatRegex(/\s/).source).toBe("\\s");
-  });
-
-  it("concatenates two regexes", () => {
-    const { concatRegex } = helper;
-    const regEx = concatRegex(/.*/, /b\s/);
-    expect(regEx.source).toBe(".*b\\s");
-  });
-});
-
 describe("functionRegex", () => {
   const { functionRegex } = helper;
   it("returns a regex", () => {

--- a/lib/__tests__/curriculum-helper.test.ts
+++ b/lib/__tests__/curriculum-helper.test.ts
@@ -312,4 +312,14 @@ describe("functionRegex", () => {
     expect(match![0]).toBe("var x = 'y'; let myFunc = (arg1, arg2) => {");
     expect(match![1]).toBe("let myFunc = (arg1, arg2) => {");
   });
+
+  it("ignores the body if there are no brackets and it's asked for the closed body", () => {
+    const code = `const naomi = (love) => 2 * love;`;
+    const funcRE = functionRegex("naomi", ["love"], {
+      closed: false,
+    });
+
+    expect(funcRE.test(code)).toBe(true);
+    expect(code.match(funcRE)![0]).toBe("const naomi = (love) => ");
+  });
 });

--- a/lib/__tests__/curriculum-helper.test.ts
+++ b/lib/__tests__/curriculum-helper.test.ts
@@ -189,6 +189,13 @@ describe("functionRegex", () => {
     expect(regEx.test("(arg1, arg2) => {}")).toBe(true);
   });
 
+  it("matches let or const declarations if they are present", () => {
+    const regEx = functionRegex("myFunc", ["arg1", "arg2"]);
+    const match = "let myFunc = (arg1, arg2) => {}".match(regEx);
+    expect(match).not.toBeNull();
+    expect(match![0]).toBe("let myFunc = (arg1, arg2) => {}");
+  });
+
   it("ignores irrelevant whitespace", () => {
     const funcName = "myFunc";
     const regEx = functionRegex(funcName, ["arg1", "arg2"]);
@@ -244,19 +251,18 @@ describe("functionRegex", () => {
   });
 
   it("can match just up to the opening bracket for an arrow function", () => {
-    const func = `naomi = (love) => {
+    const code = `const naomi = (love) => {
   return love ** 2
 }`;
-    const code = `const ${func}`;
     const startRE = functionRegex("naomi", ["love"], { closed: false });
     const endRE = /\s*return\s*love\s*\*\*\s*2\s*\}/;
     const fullRE = helper.concatRegex(startRE, endRE);
 
     expect(startRE.test(code)).toBe(true);
-    expect(code.match(startRE)![0]).toBe("naomi = (love) => {");
+    expect(code.match(startRE)![0]).toBe("const naomi = (love) => {");
 
     expect(fullRE.test(code)).toBe(true);
-    expect(code.match(fullRE)![0]).toBe(func);
+    expect(code.match(fullRE)![0]).toBe(code);
   });
 
   it("can match just up to the opening bracket for a function declaration", () => {
@@ -302,9 +308,8 @@ describe("functionRegex", () => {
       "var x = 'y'; let myFunc = (arg1, arg2) => {return true}".match(
         combinedRegEx
       );
-    console.log(combinedRegEx);
     expect(match).not.toBeNull();
-    expect(match![0]).toBe("var x = 'y'; let myFunc = (arg1, arg2) =>{");
-    expect(match![1]).toBe("let myFunc = (arg1, arg2) =>{");
+    expect(match![0]).toBe("var x = 'y'; let myFunc = (arg1, arg2) => {");
+    expect(match![1]).toBe("let myFunc = (arg1, arg2) => {");
   });
 });

--- a/lib/__tests__/curriculum-helper.test.ts
+++ b/lib/__tests__/curriculum-helper.test.ts
@@ -128,3 +128,134 @@ describe("concatRegex", () => {
     expect(regEx.source).toBe(".*b\\s");
   });
 });
+
+describe("functionRegExString", () => {
+  const { functionRegExString } = helper;
+  it("returns a string", () => {
+    expect(typeof functionRegExString("myFunc")).toBe("string");
+  });
+
+  describe("when compiled into a regular expression", () => {
+    it("matches the named function", () => {
+      const funcName = "myFunc";
+      const regEx = new RegExp(functionRegExString(funcName));
+      expect(regEx.test("function myFunc(){}")).toBe(true);
+    });
+
+    it("does not match a different named function", () => {
+      const funcName = "myFunc";
+      const regEx = new RegExp(functionRegExString(funcName));
+      expect(regEx.test("function notMyFunc(){}")).toBe(false);
+    });
+
+    it("matches the named function with arguments and a body", () => {
+      const funcName = "myFunc";
+      const regEx = new RegExp(functionRegExString(funcName, ["arg1", "arg2"]));
+      expect(
+        regEx.test("function myFunc(arg1, arg2){\n console.log()\n}")
+      ).toBe(true);
+    });
+
+    it("does not match the named function with different arguments", () => {
+      const funcName = "myFunc";
+      const regEx = new RegExp(functionRegExString(funcName, ["arg1", "arg2"]));
+      expect(regEx.test("function myFunc(arg1, arg3){}")).toBe(false);
+    });
+
+    it("matches arrow functions", () => {
+      const funcName = "myFunc";
+      const regEx = new RegExp(functionRegExString(funcName, ["arg1", "arg2"]));
+      expect(regEx.test("myFunc = (arg1, arg2) => {}")).toBe(true);
+    });
+
+    it("matches arrow functions without brackets", () => {
+      const funcName = "myFunc";
+      const regEx = new RegExp(functionRegExString(funcName, ["arg1"]));
+      expect(regEx.test("myFunc = arg1 => arg1 + 1")).toBe(true);
+    });
+
+    it("matches a function with a special character in the name", () => {
+      const funcName = "myFunc$";
+      const regEx = new RegExp(functionRegExString(funcName));
+      expect(regEx.test("function myFunc$(){}")).toBe(true);
+    });
+
+    it("matches anonymous functions", () => {
+      const regEx = new RegExp(functionRegExString(null, ["arg1", "arg2"]));
+      expect(regEx.test("function(arg1, arg2) {}")).toBe(true);
+    });
+
+    it("matches anonymous arrow functions", () => {
+      const regEx = new RegExp(functionRegExString(null, ["arg1", "arg2"]));
+      expect(regEx.test("(arg1, arg2) => {}")).toBe(true);
+    });
+
+    it("ignores irrelevant whitespace", () => {
+      const funcName = "myFunc";
+      const regEx = new RegExp(functionRegExString(funcName, ["arg1", "arg2"]));
+      expect(regEx.test("function \n\n myFunc \n ( arg1 , arg2 ) \n{ }")).toBe(
+        true
+      );
+    });
+
+    it("can be easily combined with other regex", () => {
+      const funcName = "myFunc";
+      const regEx = new RegExp(
+        `let x = ${functionRegExString(funcName)}; console\\.log\\(x\\);`
+      );
+
+      expect(regEx.test("function myFunc(){}")).toBe(false);
+      expect(regEx.test("let x = myFunc = () => {};")).toBe(false);
+      expect(regEx.test("let x = function myFunc(){}")).toBe(false);
+      expect(regEx.test("let x = myFunc = () => {}; console.log(x);")).toBe(
+        true
+      );
+      expect(regEx.test("let x = function myFunc(){}; console.log(x);")).toBe(
+        true
+      );
+    });
+
+    it("can optionally capture the function", () => {
+      const funcName = "myFunc";
+      const regEx = new RegExp(
+        functionRegExString(funcName, ["arg1", "arg2"], { capture: true })
+      );
+      const match = "var x = 'y'; function myFunc(arg1, arg2){}".match(regEx);
+      expect(match).not.toBeNull();
+      expect(match![1]).toBe("function myFunc(arg1, arg2){}");
+
+      const nonCapturingRegEx = new RegExp(
+        functionRegExString(funcName, ["arg1", "arg2"])
+      );
+      const nonCapturingMatch = "function myFunc(arg1, arg2){}".match(
+        nonCapturingRegEx
+      );
+      expect(nonCapturingMatch).not.toBeNull();
+      expect(nonCapturingMatch![1]).toBeUndefined();
+    });
+
+    it("can capture arrow functions", () => {
+      const funcName = "myFunc";
+      const regEx = new RegExp(
+        functionRegExString(funcName, ["arg1", "arg2"], { capture: true })
+      );
+      const match = "myFunc = (arg1, arg2) => {return arg1 + arg2}".match(
+        regEx
+      );
+      expect(match).not.toBeNull();
+      expect(match![1]).toBe("myFunc = (arg1, arg2) => {return arg1 + arg2}");
+    });
+
+    it("can capture functions without brackets", () => {
+      const funcName = "myFunc";
+      const regEx = new RegExp(
+        functionRegExString(funcName, ["arg1"], { capture: true })
+      );
+      const match = "myFunc = arg1 => arg1; console.log".match(regEx);
+      expect(match).not.toBeNull();
+      // It's a greedy match, since it doesn't know where the function ends.
+      // This should be fine for most use cases.
+      expect(match![1]).toBe("myFunc = arg1 => arg1; console.log");
+    });
+  });
+});

--- a/lib/__tests__/curriculum-helper.test.ts
+++ b/lib/__tests__/curriculum-helper.test.ts
@@ -244,18 +244,19 @@ describe("functionRegex", () => {
   });
 
   it("can match just up to the opening bracket for an arrow function", () => {
-    const code = `const naomi = (love) => {
+    const func = `naomi = (love) => {
   return love ** 2
 }`;
+    const code = `const ${func}`;
     const startRE = functionRegex("naomi", ["love"], { closed: false });
-    const endRE = /\s*return\s*love\s*\*\*\s*2\)/;
+    const endRE = /\s*return\s*love\s*\*\*\s*2\s*\}/;
     const fullRE = helper.concatRegex(startRE, endRE);
 
     expect(startRE.test(code)).toBe(true);
     expect(code.match(startRE)![0]).toBe("naomi = (love) => {");
 
     expect(fullRE.test(code)).toBe(true);
-    expect(code.match(fullRE)![0]).toBe(code);
+    expect(code.match(fullRE)![0]).toBe(func);
   });
 
   it("can match just up to the opening bracket for a function declaration", () => {
@@ -266,13 +267,44 @@ describe("functionRegex", () => {
     const endRE = /\s*return\s*love\s*\*\*\s*2\s\}/;
     const fullRE = helper.concatRegex(startRE, endRE);
 
-    console.log(startRE);
-    console.log(fullRE);
-
     expect(startRE.test(code)).toBe(true);
     expect(code.match(startRE)![0]).toBe("function naomi(love) {");
 
     expect(fullRE.test(code)).toBe(true);
     expect(code.match(fullRE)![0]).toBe(code);
+  });
+
+  it("can optionally capture an open function", () => {
+    const funcName = "myFunc";
+    const regEx = functionRegex(funcName, ["arg1", "arg2"], {
+      capture: true,
+      closed: false,
+    });
+    const combinedRegEx = helper.concatRegex(/var x = 'y'; /, regEx);
+
+    const match = "var x = 'y'; function myFunc(arg1, arg2){return true}".match(
+      combinedRegEx
+    );
+    expect(match).not.toBeNull();
+    expect(match![0]).toBe("var x = 'y'; function myFunc(arg1, arg2){");
+    expect(match![1]).toBe("function myFunc(arg1, arg2){");
+  });
+
+  it("can optionally capture an open arrow function", () => {
+    const funcName = "myFunc";
+    const regEx = functionRegex(funcName, ["arg1", "arg2"], {
+      capture: true,
+      closed: false,
+    });
+    const combinedRegEx = helper.concatRegex(/var x = 'y'; /, regEx);
+
+    const match =
+      "var x = 'y'; let myFunc = (arg1, arg2) => {return true}".match(
+        combinedRegEx
+      );
+    console.log(combinedRegEx);
+    expect(match).not.toBeNull();
+    expect(match![0]).toBe("var x = 'y'; let myFunc = (arg1, arg2) =>{");
+    expect(match![1]).toBe("let myFunc = (arg1, arg2) =>{");
   });
 });

--- a/lib/__tests__/curriculum-helper.test.ts
+++ b/lib/__tests__/curriculum-helper.test.ts
@@ -158,19 +158,19 @@ describe("functionRegex", () => {
 
   it("matches the named function", () => {
     const funcName = "myFunc";
-    const regEx = new RegExp(functionRegex(funcName));
+    const regEx = functionRegex(funcName);
     expect(regEx.test("function myFunc(){}")).toBe(true);
   });
 
   it("does not match a different named function", () => {
     const funcName = "myFunc";
-    const regEx = new RegExp(functionRegex(funcName));
+    const regEx = functionRegex(funcName);
     expect(regEx.test("function notMyFunc(){}")).toBe(false);
   });
 
   it("matches the named function with arguments and a body", () => {
     const funcName = "myFunc";
-    const regEx = new RegExp(functionRegex(funcName, ["arg1", "arg2"]));
+    const regEx = functionRegex(funcName, ["arg1", "arg2"]);
     expect(regEx.test("function myFunc(arg1, arg2){\n console.log()\n}")).toBe(
       true
     );
@@ -178,41 +178,41 @@ describe("functionRegex", () => {
 
   it("does not match the named function with different arguments", () => {
     const funcName = "myFunc";
-    const regEx = new RegExp(functionRegex(funcName, ["arg1", "arg2"]));
+    const regEx = functionRegex(funcName, ["arg1", "arg2"]);
     expect(regEx.test("function myFunc(arg1, arg3){}")).toBe(false);
   });
 
   it("matches arrow functions", () => {
     const funcName = "myFunc";
-    const regEx = new RegExp(functionRegex(funcName, ["arg1", "arg2"]));
+    const regEx = functionRegex(funcName, ["arg1", "arg2"]);
     expect(regEx.test("myFunc = (arg1, arg2) => {}")).toBe(true);
   });
 
   it("matches arrow functions without brackets", () => {
     const funcName = "myFunc";
-    const regEx = new RegExp(functionRegex(funcName, ["arg1"]));
+    const regEx = functionRegex(funcName, ["arg1"]);
     expect(regEx.test("myFunc = arg1 => arg1 + 1")).toBe(true);
   });
 
   it("matches a function with a special character in the name", () => {
     const funcName = "myFunc$";
-    const regEx = new RegExp(functionRegex(funcName));
+    const regEx = functionRegex(funcName);
     expect(regEx.test("function myFunc$(){}")).toBe(true);
   });
 
   it("matches anonymous functions", () => {
-    const regEx = new RegExp(functionRegex(null, ["arg1", "arg2"]));
+    const regEx = functionRegex(null, ["arg1", "arg2"]);
     expect(regEx.test("function(arg1, arg2) {}")).toBe(true);
   });
 
   it("matches anonymous arrow functions", () => {
-    const regEx = new RegExp(functionRegex(null, ["arg1", "arg2"]));
+    const regEx = functionRegex(null, ["arg1", "arg2"]);
     expect(regEx.test("(arg1, arg2) => {}")).toBe(true);
   });
 
   it("ignores irrelevant whitespace", () => {
     const funcName = "myFunc";
-    const regEx = new RegExp(functionRegex(funcName, ["arg1", "arg2"]));
+    const regEx = functionRegex(funcName, ["arg1", "arg2"]);
     expect(regEx.test("function \n\n myFunc \n ( arg1 , arg2 ) \n{ }")).toBe(
       true
     );

--- a/lib/__tests__/curriculum-helper.test.ts
+++ b/lib/__tests__/curriculum-helper.test.ts
@@ -196,4 +196,50 @@ describe("functionRegex", () => {
       true
     );
   });
+
+  it("can optionally capture the function", () => {
+    const funcName = "myFunc";
+    const regEx = functionRegex(funcName, ["arg1", "arg2"], { capture: true });
+    const combinedRegEx = helper.concatRegex(/var x = 'y'; /, regEx);
+
+    const match = "var x = 'y'; function myFunc(arg1, arg2){}".match(
+      combinedRegEx
+    );
+    expect(match).not.toBeNull();
+    expect(match![0]).toBe("var x = 'y'; function myFunc(arg1, arg2){}");
+    expect(match![1]).toBe("function myFunc(arg1, arg2){}");
+
+    const nonCapturingRegEx = functionRegex(funcName, ["arg1", "arg2"]);
+
+    const nonCapturingMatch = "function myFunc(arg1, arg2){}".match(
+      nonCapturingRegEx
+    );
+    expect(nonCapturingMatch).not.toBeNull();
+    expect(nonCapturingMatch![1]).toBeUndefined();
+  });
+
+  it("can capture arrow functions", () => {
+    const funcName = "myFunc";
+    const regEx = functionRegex(funcName, ["arg1", "arg2"], { capture: true });
+
+    const match = "myFunc = (arg1, arg2) => {return arg1 + arg2}".match(regEx);
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe("myFunc = (arg1, arg2) => {return arg1 + arg2}");
+  });
+
+  it("can capture functions without brackets", () => {
+    const funcName = "myFunc";
+    const regEx = functionRegex(funcName, ["arg1"], { capture: true });
+
+    const match =
+      "myFunc = arg1 => arg1; console.log()\n // captured, unfortunately".match(
+        regEx
+      );
+    expect(match).not.toBeNull();
+    // It's a greedy match, since it doesn't know where the function ends.
+    // This should be fine for most use cases.
+    expect(match![1]).toBe(
+      "myFunc = arg1 => arg1; console.log()\n // captured, unfortunately"
+    );
+  });
 });

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -84,6 +84,29 @@ export function concatRegex(...regexes: (string | RegExp)[]) {
   return new RegExp(source);
 }
 
+/**
+ * Generates a regex string to match a function expressions and declarations
+ * @param funcName - The name of the function to be matched
+ * @param paramList - Optional list of parameters to be matched
+ * @param options - Optional object determining whether to capture the match (defaults to non-capturing)
+ */
+
+export function functionRegExString(
+  funcName: string | null,
+  paramList: string[] = [],
+  { capture }: { capture: boolean } = { capture: false }
+): string {
+  const params = paramList.join("\\s*,\\s*");
+  const normalFunctionName = funcName ? "\\s" + escapeRegExp(funcName) : "";
+  const arrowFunctionName = funcName
+    ? `${escapeRegExp(funcName)}\\s*=\\s*`
+    : "";
+  const body = "[^}]*";
+  const funcRegEx = `function\\s*${normalFunctionName}\\s*\\(\\s*${params}\\s*\\)\\s*\\{${body}\\}`;
+  const arrowFuncRegEx = `${arrowFunctionName}\\(?\\s*${params}\\s*\\)?\\s*=>\\s*\\{?${body}\\}?`;
+  return `(${capture ? "" : "?:"}${funcRegEx}|${arrowFuncRegEx})`;
+}
+
 export interface ExtendedStyleRule extends CSSStyleRule {
   isDeclaredAfter: (selector: string) => boolean;
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -88,16 +88,18 @@ export function concatRegex(...regexes: (string | RegExp)[]) {
  * Generates a regex string to match a function expressions and declarations
  * @param funcName - The name of the function to be matched
  * @param paramList - Optional list of parameters to be matched
- * @param options - Optional object determining whether to capture the match (defaults to non-capturing)
+ * @param options - Optional object determining whether to capture the match
+ * (defaults to non-capturing) and whether to include the body in the match (defaults
+ * to true)
  */
 
 export function functionRegex(
   funcName: string | null,
   paramList?: string[],
-  options?: { capture?: boolean; closed?: boolean }
+  options?: { capture?: boolean; includeBody?: boolean }
 ): RegExp {
   const capture = options?.capture ?? false;
-  const closed = options?.closed ?? true;
+  const includeBody = options?.includeBody ?? true;
   const params = (paramList ?? []).join("\\s*,\\s*");
 
   const normalFunctionName = funcName ? "\\s" + escapeRegExp(funcName) : "";
@@ -108,11 +110,13 @@ export function functionRegex(
 
   const funcREHead = `function\\s*${normalFunctionName}\\s*\\(\\s*${params}\\s*\\)\\s*\\{`;
   const funcREBody = `${body}\\}`;
-  const funcRegEx = closed ? `${funcREHead}${funcREBody}` : `${funcREHead}`;
+  const funcRegEx = includeBody
+    ? `${funcREHead}${funcREBody}`
+    : `${funcREHead}`;
 
   const arrowFuncREHead = `${arrowFunctionName}\\(?\\s*${params}\\s*\\)?\\s*=>\\s*\\{?`;
   const arrowFuncREBody = `${body}\\}?`;
-  const arrowFuncRegEx = closed
+  const arrowFuncRegEx = includeBody
     ? `${arrowFuncREHead}${arrowFuncREBody}`
     : `${arrowFuncREHead}`;
   return new RegExp(`(${capture ? "" : "?:"}${funcRegEx}|${arrowFuncRegEx})`);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -91,7 +91,7 @@ export function concatRegex(...regexes: (string | RegExp)[]) {
  * @param options - Optional object determining whether to capture the match (defaults to non-capturing)
  */
 
-export function functionRegexString(
+export function functionRegex(
   funcName: string | null,
   paramList: string[] = [],
   { capture }: { capture: boolean } = { capture: false }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -95,7 +95,7 @@ export function functionRegex(
   funcName: string | null,
   paramList: string[] = [],
   { capture }: { capture: boolean } = { capture: false }
-): string {
+): RegExp {
   const params = paramList.join("\\s*,\\s*");
   const normalFunctionName = funcName ? "\\s" + escapeRegExp(funcName) : "";
   const arrowFunctionName = funcName
@@ -104,7 +104,7 @@ export function functionRegex(
   const body = "[^}]*";
   const funcRegEx = `function\\s*${normalFunctionName}\\s*\\(\\s*${params}\\s*\\)\\s*\\{${body}\\}`;
   const arrowFuncRegEx = `${arrowFunctionName}\\(?\\s*${params}\\s*\\)?\\s*=>\\s*\\{?${body}\\}?`;
-  return `(${capture ? "" : "?:"}${funcRegEx}|${arrowFuncRegEx})`;
+  return new RegExp(`(${capture ? "" : "?:"}${funcRegEx}|${arrowFuncRegEx})`);
 }
 
 export interface ExtendedStyleRule extends CSSStyleRule {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -102,7 +102,7 @@ export function functionRegex(
 
   const normalFunctionName = funcName ? "\\s" + escapeRegExp(funcName) : "";
   const arrowFunctionName = funcName
-    ? `${escapeRegExp(funcName)}\\s*=\\s*`
+    ? `(let|const|var)?\\s?${escapeRegExp(funcName)}\\s*=\\s*`
     : "";
   const body = "[^}]*";
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -109,7 +109,12 @@ export function functionRegex(
   const funcREHead = `function\\s*${normalFunctionName}\\s*\\(\\s*${params}\\s*\\)\\s*\\{`;
   const funcREBody = `${body}\\}`;
   const funcRegEx = closed ? `${funcREHead}${funcREBody}` : `${funcREHead}`;
-  const arrowFuncRegEx = `${arrowFunctionName}\\(?\\s*${params}\\s*\\)?\\s*=>\\s*\\{?${body}\\}?`;
+
+  const arrowFuncREHead = `${arrowFunctionName}\\(?\\s*${params}\\s*\\)?\\s*=>\\s*\\{?`;
+  const arrowFuncREBody = `${body}\\}?`;
+  const arrowFuncRegEx = closed
+    ? `${arrowFuncREHead}${arrowFuncREBody}`
+    : `${arrowFuncREHead}`;
   return new RegExp(`(${capture ? "" : "?:"}${funcRegEx}|${arrowFuncRegEx})`);
 }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -91,7 +91,7 @@ export function concatRegex(...regexes: (string | RegExp)[]) {
  * @param options - Optional object determining whether to capture the match (defaults to non-capturing)
  */
 
-export function functionRegExString(
+export function functionRegexString(
   funcName: string | null,
   paramList: string[] = [],
   { capture }: { capture: boolean } = { capture: false }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -93,16 +93,22 @@ export function concatRegex(...regexes: (string | RegExp)[]) {
 
 export function functionRegex(
   funcName: string | null,
-  paramList: string[] = [],
-  { capture }: { capture: boolean } = { capture: false }
+  paramList?: string[],
+  options?: { capture?: boolean; closed?: boolean }
 ): RegExp {
-  const params = paramList.join("\\s*,\\s*");
+  const capture = options?.capture ?? false;
+  const closed = options?.closed ?? true;
+  const params = (paramList ?? []).join("\\s*,\\s*");
+
   const normalFunctionName = funcName ? "\\s" + escapeRegExp(funcName) : "";
   const arrowFunctionName = funcName
     ? `${escapeRegExp(funcName)}\\s*=\\s*`
     : "";
   const body = "[^}]*";
-  const funcRegEx = `function\\s*${normalFunctionName}\\s*\\(\\s*${params}\\s*\\)\\s*\\{${body}\\}`;
+
+  const funcREHead = `function\\s*${normalFunctionName}\\s*\\(\\s*${params}\\s*\\)\\s*\\{`;
+  const funcREBody = `${body}\\}`;
+  const funcRegEx = closed ? `${funcREHead}${funcREBody}` : `${funcREHead}`;
   const arrowFuncRegEx = `${arrowFunctionName}\\(?\\s*${params}\\s*\\)?\\s*=>\\s*\\{?${body}\\}?`;
   return new RegExp(`(${capture ? "" : "?:"}${funcRegEx}|${arrowFuncRegEx})`);
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

TODO

- [x] Docs
- [x] Return RegExp instead of string (it's trivial to combine them with other regexes)
- [x] Test against fcc curriculum

The docs should explain this pretty well, but the gist is: this function provides a regex to match function expressions/declarations and arrow functions. 

<!-- Feel free to add any additional description of changes below this line -->
