### PR TITLE
feat: basic js ast explorer

### DIFF
--- a/lib/__tests__/tower.test.ts
+++ b/lib/__tests__/tower.test.ts
@@ -1,0 +1,66 @@
+/* eslint-disable */
+import { Tower } from "../index";
+
+const code = `
+import { readFile } from "fs/promises";
+
+async function main() {
+  doSyncStuff();
+
+  const a = await doAsyncStuff(1);
+  console.log(a);
+}
+
+// Test
+async function doAsyncStuff(num) {
+  // Another test
+  const file = await readFile("file_loc" + num, "utf-8");
+  return file;
+}
+
+const a = [];
+
+const b = {
+  c: () => {
+    const c = 1;
+  },
+  "example-a": {
+    a: 1
+  }
+}
+
+const { c, d, e } = b;
+
+const [f, g] = [c, d];
+
+let h, i;
+
+a.map(function (e) {});
+
+function doSyncStuff() {
+  console.log("stuff");
+}
+
+main();
+`;
+
+const t = new Tower(code);
+
+describe("tower", () => {
+  describe("getFunction", () => {
+    it("works", () => {
+      const main = t.getFunction("main").generate;
+      console.log(main);
+    });
+  });
+  describe("getVariable", () => {
+    it("works", () => {
+      const a = t.getFunction("main").getVariable("a").generate;
+      const b = t.getVariable("b").generate;
+      const file = t.getFunction("doAsyncStuff").getVariable("file").generate;
+      console.log(a);
+      console.log(b);
+      console.log(file);
+    });
+  });
+});

--- a/lib/__tests__/tower.test.ts
+++ b/lib/__tests__/tower.test.ts
@@ -56,7 +56,7 @@ describe("tower", () => {
   console.log(a);
 }
 
-// Test`
+// Test`,
       );
     });
   });
@@ -75,7 +75,7 @@ describe("tower", () => {
 };`);
       const file = t.getFunction("doAsyncStuff").getVariable("file").generate;
       expect(file).toEqual(
-        '// Another test\nconst file = await readFile("file_loc" + num, "utf-8");'
+        '// Another test\nconst file = await readFile("file_loc" + num, "utf-8");',
       );
     });
   });
@@ -87,7 +87,7 @@ describe("tower", () => {
       // @ts-expect-error - expression does exist.
       const argumes = map?.ast.expression?.arguments;
       expect(generate(argumes.at(0), { compact: true }).code).toEqual(
-        "function(e){}"
+        "function(e){}",
       );
     });
   });

--- a/lib/class/tower.ts
+++ b/lib/class/tower.ts
@@ -1,0 +1,91 @@
+/* eslint-disable */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { parse, ParserOptions } from "@babel/parser";
+import generate, { GeneratorOptions } from "@babel/generator";
+import {
+  ArrowFunctionExpression,
+  ExpressionStatement,
+  FunctionDeclaration,
+  Identifier,
+  ImportDeclaration,
+  is,
+  Node,
+  VariableDeclaration,
+  Statement,
+  Program,
+  File,
+  Declaration,
+} from "@babel/types";
+
+export class Tower<T extends Node> {
+  public ast: Node;
+  constructor(stringOrAST: string | T, options?: Partial<ParserOptions>) {
+    if (typeof stringOrAST === "string") {
+      const parsedThing = parse(stringOrAST, {
+        sourceType: "module",
+        ...options,
+      });
+      this.ast = parsedThing.program;
+    } else {
+      this.ast = stringOrAST;
+    }
+  }
+
+  // Get all the given types at the current scope
+  private getType<T extends Node>(type: string, name: string): Tower<T> {
+    const body = this.extractBody(this.ast);
+    const ast = body.find((node) => {
+      if (node.type === type) {
+        if (is("FunctionDeclaration", node)) {
+          return node.id?.name === name;
+        }
+        if (is("VariableDeclaration", node)) {
+          const variableDeclarator = node.declarations[0];
+          if (!is("VariableDeclarator", variableDeclarator)) {
+            return false;
+          }
+          const identifier = variableDeclarator.id;
+          if (!is("Identifier", identifier)) {
+            return false;
+          }
+          return identifier.name === name;
+        }
+      }
+      return false;
+    });
+    if (!ast) {
+      throw new Error(`No AST found with name ${name}`);
+    }
+    assertIsType<T>(ast);
+    return new Tower<T>(ast);
+  }
+
+  public getFunction(name: string): Tower<FunctionDeclaration> {
+    return this.getType("FunctionDeclaration", name);
+  }
+
+  public getVariable(name: string): Tower<VariableDeclaration> {
+    return this.getType("VariableDeclaration", name);
+  }
+
+  private extractBody(ast: Node): Node[] {
+    switch (ast.type) {
+      case "Program":
+        return ast.body;
+      case "FunctionDeclaration":
+        return ast.body.body;
+      case "VariableDeclaration":
+        return ast.declarations;
+      default:
+        throw new Error(`Unimplemented for ${ast.type}`);
+    }
+  }
+
+  public get generate(): string {
+    return generate(this.ast).code;
+  }
+}
+
+function assertIsType<T extends Node>(ast: Node): asserts ast is T {
+  return;
+}

--- a/lib/class/tower.ts
+++ b/lib/class/tower.ts
@@ -85,6 +85,22 @@ export class Tower<T extends Node> {
         }
       }
 
+      if (is("VariableDeclarator", node)) {
+        const init = node.init;
+        if (is("CallExpression", init)) {
+          const callee = init.callee;
+
+          switch (callee.type) {
+            case "Identifier":
+              return callee.name === callSite;
+            case "MemberExpression":
+              return generate(callee).code === callSite;
+            default:
+              return true;
+          }
+        }
+      }
+
       return false;
     });
     assertIsType<ExpressionStatement[]>(calls);

--- a/lib/class/tower.ts
+++ b/lib/class/tower.ts
@@ -138,5 +138,5 @@ export class Tower<T extends Node> {
 }
 
 function assertIsType<T extends Node | Node[]>(
-  ast: Node | Node[]
+  ast: Node | Node[],
 ): asserts ast is T {}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,6 @@
 import { strip } from "./strip";
 import astHelpers from "../python/py_helpers.py";
-export { Tower } from "./class/tower";
+export { Tower, generate } from "./class/tower";
 
 declare global {
   // eslint-disable-next-line no-var

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,6 @@
 import { strip } from "./strip";
 import astHelpers from "../python/py_helpers.py";
+export { Tower } from "./class/tower";
 
 declare global {
   // eslint-disable-next-line no-var

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "build": "NODE_ENV=production webpack",
     "clean": "rm -rf dist",
     "lint": "eslint lib --max-warnings 0 && prettier lib --check",
+    "format": "prettier --write lib",
     "test": "jest",
     "prepublishOnly": "pnpm clean && pnpm build",
     "webpack": "webpack"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@babel/preset-env": "7.26.9",
     "@babel/preset-react": "^7.26.3",
     "@babel/preset-typescript": "7.26.0",
+    "@types/babel__generator": "^7.6.8",
     "@types/jest": "29.5.14",
     "@typescript-eslint/eslint-plugin": "^6.13.1",
     "@typescript-eslint/parser": "^6.13.1",
@@ -82,6 +83,9 @@
   "repository": "git@github.com:freeCodeCamp/curriculum-helpers.git",
   "license": "BSD-3-Clause",
   "dependencies": {
+    "@babel/generator": "7.26.9",
+    "@babel/parser": "7.26.9",
+    "@babel/types": "7.26.9",
     "browserify": "^17.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@babel/generator':
+        specifier: 7.26.9
+        version: 7.26.9
+      '@babel/parser':
+        specifier: 7.26.9
+        version: 7.26.9
+      '@babel/types':
+        specifier: 7.26.9
+        version: 7.26.9
       browserify:
         specifier: ^17.0.0
         version: 17.0.1
@@ -24,6 +33,9 @@ importers:
       '@babel/preset-typescript':
         specifier: 7.26.0
         version: 7.26.0(@babel/core@7.26.9)
+      '@types/babel__generator':
+        specifier: ^7.6.8
+        version: 7.6.8
       '@types/jest':
         specifier: 29.5.14
         version: 29.5.14

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "declaration": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "strict": true
+    "strict": true,
+    "moduleResolution": "Node10"
   }
 }


### PR DESCRIPTION
This is a more basic AST explorer than Babeliser. I am still not 100% about the API, but have already started adding/using it in:
https://github.com/freeCodeCamp/back-end-development-and-apis/blob/64f5270dab04eb80026aed10f91dfdfda4dfda3d/curriculum/locales/english/learn-npm-by-building-an-npm-module.md?plain=1#L1298-L1317