### PR TITLE
feat: permutateRegex

### DIFF
--- a/docs/curriculum-helpers.md
+++ b/docs/curriculum-helpers.md
@@ -82,9 +82,39 @@ element.querySelector("h1").textContent === "Some Value";
 Permutates regular expressions or source strings, to create regex matching elements in any order.
 
 ```javascript
-const source1 = `titleInput\\.value\\s*(?:!==|!=)\\s*currentTask\\.title`;
-const regex1 = /dateInput\.value\s*(?:!==|!=)\s*currentTask\.date/;
-const source2 = `descriptionInput\\.value\\s*(?:!==|!=)\\s*currentTask\\.description`;
 
-permutateRegex([source1, regex1, source2]).source === new RegExp(/(?:titleInput\.value\s*(?:!==|!=)\s*currentTask\.title\s*\|\|\s*dateInput\.value\s*(?:!==|!=)\s*currentTask\.date\s*\|\|\s*descriptionInput\.value\s*(?:!==|!=)\s*currentTask\.description|dateInput\.value\s*(?:!==|!=)\s*currentTask\.date\s*\|\|\s*titleInput\.value\s*(?:!==|!=)\s*currentTask\.title\s*\|\|\s*descriptionInput\.value\s*(?:!==|!=)\s*currentTask\.description|descriptionInput\.value\s*(?:!==|!=)\s*currentTask\.description\s*\|\|\s*titleInput\.value\s*(?:!==|!=)\s*currentTask\.title\s*\|\|\s*dateInput\.value\s*(?:!==|!=)\s*currentTask\.date|titleInput\.value\s*(?:!==|!=)\s*currentTask\.title\s*\|\|\s*descriptionInput\.value\s*(?:!==|!=)\s*currentTask\.description\s*\|\|\s*dateInput\.value\s*(?:!==|!=)\s*currentTask\.date|dateInput\.value\s*(?:!==|!=)\s*currentTask\.date\s*\|\|\s*descriptionInput\.value\s*(?:!==|!=)\s*currentTask\.description\s*\|\|\s*titleInput\.value\s*(?:!==|!=)\s*currentTask\.title|descriptionInput\.value\s*(?:!==|!=)\s*currentTask\.description\s*\|\|\s*dateInput\.value\s*(?:!==|!=)\s*currentTask\.date\s*\|\|\s*titleInput\.value\s*(?:!==|!=)\s*currentTask\.title)/).source;
+Inputs can have capturing groups, but both groups and backreferrences need to be named. In the resulting regex they will be renamed to avoid duplicated names, and to allow backreferrences to refer to correct group.
+
+```javascript
+const regex = permutateRegex(
+    [
+        'a',
+        /(?<ref>'|"|`)b\k<ref>/
+    ],
+    { elementsSeparator: String.raw`\s*===\s*` }
+);
+
+regex.source === new RegExp(/(?:a\s*===\s*(?<ref_0>'|"|`)b\k<ref_0>|(?<ref_1>'|"|`)b\k<ref_1>\s*===\s*a)/).source;
+
+regex.test('a === "b"') // true
+regex.test("'b' === a") // true
+regex.test('a === `b`') // true
+regex.test(`a === 'b"`) // false
+```
+
+### Options
+- capture: boolean - Whole regex is wrapped in regex group. If `capture` is `true` the group will be capturing, otherwise it will be non-capturing. Defaults to `false`.
+- elementsSeparator: string - Separates permutated elements within single permutation. Defaults to `\s*\|\|\s*`.
+- permutationsSeparator: string - Separates permutations. Defaults to `|`.
+
+```js
+permutateRegex(['a', /b/, 'c'], { capture: true }).source === new RegExp(/(a\s*\|\|\s*b\s*\|\|\s*c|b\s*\|\|\s*a\s*\|\|\s*c|c\s*\|\|\s*a\s*\|\|\s*b|a\s*\|\|\s*c\s*\|\|\s*b|b\s*\|\|\s*c\s*\|\|\s*a|c\s*\|\|\s*b\s*\|\|\s*a)/).source
+```
+
+```js
+permutateRegex(['a', /b/, 'c'], { elementsSeparator: ',' }).source === new RegExp(/(?:a,b,c|b,a,c|c,a,b|a,c,b|b,c,a|c,b,a)/).source
+```
+
+```js
+permutateRegex(['a', /b/, 'c'], { permutationsSeparator: '&' }).source === new RegExp(/(?:a\s*\|\|\s*b\s*\|\|\s*c&b\s*\|\|\s*a\s*\|\|\s*c&c\s*\|\|\s*a\s*\|\|\s*b&a\s*\|\|\s*c\s*\|\|\s*b&b\s*\|\|\s*c\s*\|\|\s*a&c\s*\|\|\s*b\s*\|\|\s*a)/).source
 ```

--- a/docs/curriculum-helpers.md
+++ b/docs/curriculum-helpers.md
@@ -82,6 +82,12 @@ element.querySelector("h1").textContent === "Some Value";
 Permutates regular expressions or source strings, to create regex matching elements in any order.
 
 ```javascript
+const source1 = 'a';
+const regex1 = /b/;
+const source2 = 'c';
+
+permutateRegex([source1, regex1, source2]).source === new RegExp(/(?:a\s*\|\|\s*b\s*\|\|\s*c|b\s*\|\|\s*a\s*\|\|\s*c|c\s*\|\|\s*a\s*\|\|\s*b|a\s*\|\|\s*c\s*\|\|\s*b|b\s*\|\|\s*c\s*\|\|\s*a|c\s*\|\|\s*b\s*\|\|\s*a)/).source;
+```
 
 Inputs can have capturing groups, but both groups and backreferrences need to be named. In the resulting regex they will be renamed to avoid duplicated names, and to allow backreferrences to refer to correct group.
 

--- a/docs/curriculum-helpers.md
+++ b/docs/curriculum-helpers.md
@@ -76,3 +76,15 @@ import { SomeComponent } from "./SomeComponent";
 const element = await prepTestComponent(SomeComponent, { someProp: "someValue" });
 element.querySelector("h1").textContent === "Some Value";
 ```
+
+## permutateRegex
+
+Permutates regular expressions or source strings, to create regex matching elements in any order.
+
+```javascript
+const source1 = `titleInput\\.value\\s*(?:!==|!=)\\s*currentTask\\.title`;
+const regex1 = /dateInput\.value\s*(?:!==|!=)\s*currentTask\.date/;
+const source2 = `descriptionInput\\.value\\s*(?:!==|!=)\\s*currentTask\\.description`;
+
+permutateRegex([source1, regex1, source2]).source === new RegExp(/(?:titleInput\.value\s*(?:!==|!=)\s*currentTask\.title\s*\|\|\s*dateInput\.value\s*(?:!==|!=)\s*currentTask\.date\s*\|\|\s*descriptionInput\.value\s*(?:!==|!=)\s*currentTask\.description|dateInput\.value\s*(?:!==|!=)\s*currentTask\.date\s*\|\|\s*titleInput\.value\s*(?:!==|!=)\s*currentTask\.title\s*\|\|\s*descriptionInput\.value\s*(?:!==|!=)\s*currentTask\.description|descriptionInput\.value\s*(?:!==|!=)\s*currentTask\.description\s*\|\|\s*titleInput\.value\s*(?:!==|!=)\s*currentTask\.title\s*\|\|\s*dateInput\.value\s*(?:!==|!=)\s*currentTask\.date|titleInput\.value\s*(?:!==|!=)\s*currentTask\.title\s*\|\|\s*descriptionInput\.value\s*(?:!==|!=)\s*currentTask\.description\s*\|\|\s*dateInput\.value\s*(?:!==|!=)\s*currentTask\.date|dateInput\.value\s*(?:!==|!=)\s*currentTask\.date\s*\|\|\s*descriptionInput\.value\s*(?:!==|!=)\s*currentTask\.description\s*\|\|\s*titleInput\.value\s*(?:!==|!=)\s*currentTask\.title|descriptionInput\.value\s*(?:!==|!=)\s*currentTask\.description\s*\|\|\s*dateInput\.value\s*(?:!==|!=)\s*currentTask\.date\s*\|\|\s*titleInput\.value\s*(?:!==|!=)\s*currentTask\.title)/).source;
+```

--- a/docs/curriculum-helpers.md
+++ b/docs/curriculum-helpers.md
@@ -113,14 +113,14 @@ regex.test(`a === 'b"`) // false
 - elementsSeparator: string - Separates permutated elements within single permutation. Defaults to `\s*\|\|\s*`.
 - permutationsSeparator: string - Separates permutations. Defaults to `|`.
 
-```js
+```javascript
 permutateRegex(['a', /b/, 'c'], { capture: true }).source === new RegExp(/(a\s*\|\|\s*b\s*\|\|\s*c|b\s*\|\|\s*a\s*\|\|\s*c|c\s*\|\|\s*a\s*\|\|\s*b|a\s*\|\|\s*c\s*\|\|\s*b|b\s*\|\|\s*c\s*\|\|\s*a|c\s*\|\|\s*b\s*\|\|\s*a)/).source
 ```
 
-```js
+```javascript
 permutateRegex(['a', /b/, 'c'], { elementsSeparator: ',' }).source === new RegExp(/(?:a,b,c|b,a,c|c,a,b|a,c,b|b,c,a|c,b,a)/).source
 ```
 
-```js
+```javascript
 permutateRegex(['a', /b/, 'c'], { permutationsSeparator: '&' }).source === new RegExp(/(?:a\s*\|\|\s*b\s*\|\|\s*c&b\s*\|\|\s*a\s*\|\|\s*c&c\s*\|\|\s*a\s*\|\|\s*b&a\s*\|\|\s*c\s*\|\|\s*b&b\s*\|\|\s*c\s*\|\|\s*a&c\s*\|\|\s*b\s*\|\|\s*a)/).source
 ```

--- a/lib/__tests__/curriculum-helper.test.tsx
+++ b/lib/__tests__/curriculum-helper.test.tsx
@@ -476,3 +476,74 @@ describe("prepTestComponent", () => {
     expect(spy).not.toHaveBeenCalled();
   });
 });
+
+describe("permutateRegex", () => {
+  it("returns a Regex", () => {
+    const { permutateRegex } = helper;
+
+    expect(permutateRegex([/a/, /b/])).toBeInstanceOf(RegExp);
+    expect(permutateRegex([/a/, "b"])).toBeInstanceOf(RegExp);
+    expect(permutateRegex(["a", "b"])).toBeInstanceOf(RegExp);
+  });
+
+  it("returns regex matching all permutations", () => {
+    const { permutateRegex } = helper;
+    const regex = permutateRegex(["a", "b", /c/]);
+
+    expect(regex.test("a||b||c")).toBe(true);
+    expect(regex.test("a||c||b")).toBe(true);
+    expect(regex.test("b||a||c")).toBe(true);
+    expect(regex.test("b||c||a")).toBe(true);
+    expect(regex.test("c||a||b")).toBe(true);
+    expect(regex.test("c||b||a")).toBe(true);
+    expect(regex.source).not.toEqual("(?:)");
+  });
+
+  it("returns regex not matching invalid permutation", () => {
+    const { permutateRegex } = helper;
+    const regex = permutateRegex(["a", "b", "c"]);
+
+    expect(regex.test("")).toBe(false);
+    expect(regex.test("a")).toBe(false);
+    expect(regex.test("a||a")).toBe(false);
+    expect(regex.test("a||a||a")).toBe(false);
+    expect(regex.test("b")).toBe(false);
+    expect(regex.test("b||b")).toBe(false);
+    expect(regex.test("b||b||b")).toBe(false);
+    expect(regex.test("c")).toBe(false);
+    expect(regex.test("c||c")).toBe(false);
+    expect(regex.test("c||c||c")).toBe(false);
+    expect(regex.test("a||b")).toBe(false);
+    expect(regex.test("a||b||a")).toBe(false);
+    expect(regex.test("a||b||b")).toBe(false);
+  });
+
+  it("returns regex using custom elementsSeparator", () => {
+    const { permutateRegex } = helper;
+    const regex = permutateRegex(["a", "b", "c"], { elementsSeparator: "," });
+
+    expect(regex.test("a,b,c")).toBe(true);
+    expect(regex.test("a,c,b")).toBe(true);
+    expect(regex.test("b,a,c")).toBe(true);
+    expect(regex.test("b,c,a")).toBe(true);
+    expect(regex.test("c,a,b")).toBe(true);
+    expect(regex.test("c,b,a")).toBe(true);
+  });
+
+  it("returns capturing regex when capture option is true", () => {
+    const { permutateRegex } = helper;
+    const regex = permutateRegex(["a", "b", "c"], { capture: true });
+
+    console.log(regex);
+
+    expect("b||c||a".match(regex)?.length).toEqual(2);
+    expect("b||c||a".match(regex)?.[1]).toEqual("b||c||a");
+  });
+
+  it("returns not capturing regex when capture option is false", () => {
+    const { permutateRegex } = helper;
+    const regex = permutateRegex(["a", "b", "c"], { capture: false });
+
+    expect("b||c||a".match(regex)?.length).toEqual(1);
+  });
+});

--- a/lib/__tests__/curriculum-helper.test.tsx
+++ b/lib/__tests__/curriculum-helper.test.tsx
@@ -550,7 +550,7 @@ describe("permutateRegex", () => {
     expect(() =>
       permutateRegex([/messageInput\.value/, /(?<ref>'|"|`)\k<ref>/], {
         elementsSeparator: String.raw`\s*===?\s*`,
-      })
+      }),
     ).not.toThrow();
   });
 

--- a/lib/__tests__/curriculum-helper.test.tsx
+++ b/lib/__tests__/curriculum-helper.test.tsx
@@ -546,4 +546,34 @@ describe("permutateRegex", () => {
 
     expect("b||c||a".match(regex)?.length).toEqual(1);
   });
+
+  it("renames capturing named groups to avoid duplicated group names", () => {
+    const { permutateRegex } = helper;
+
+    expect(() =>
+      permutateRegex([/messageInput\.value/, /(?<ref>'|"|`)\k<ref>/], {
+        elementsSeparator: String.raw`\s*===?\s*`,
+      })
+    ).not.toThrow();
+  });
+
+  it("returns regex correctly backreferrencing the capturing named groups", () => {
+    const { permutateRegex } = helper;
+    const regex = permutateRegex([/a/, /(?<ref>'|"|`)b\k<ref>/], {
+      elementsSeparator: String.raw`\s*===?\s*`,
+    });
+
+    expect(regex.test("a === 'b'")).toBe(true);
+    expect(regex.test("a === `b`")).toBe(true);
+    expect(regex.test('a === "b"')).toBe(true);
+    expect(regex.test("'b' === a")).toBe(true);
+    expect(regex.test("`b` === a")).toBe(true);
+    expect(regex.test('"b" === a')).toBe(true);
+
+    expect(regex.test("a === `b'")).toBe(false);
+    expect(regex.test(`a === "b'`)).toBe(false);
+    expect(regex.test("'b` === a")).toBe(false);
+    expect(regex.test('`b" === a')).toBe(false);
+    expect(regex.test(`'b" === a`)).toBe(false);
+  });
 });

--- a/lib/__tests__/curriculum-helper.test.tsx
+++ b/lib/__tests__/curriculum-helper.test.tsx
@@ -496,7 +496,6 @@ describe("permutateRegex", () => {
     expect(regex.test("b||c||a")).toBe(true);
     expect(regex.test("c||a||b")).toBe(true);
     expect(regex.test("c||b||a")).toBe(true);
-    expect(regex.source).not.toEqual("(?:)");
   });
 
   it("returns regex not matching invalid permutation", () => {
@@ -533,8 +532,6 @@ describe("permutateRegex", () => {
   it("returns capturing regex when capture option is true", () => {
     const { permutateRegex } = helper;
     const regex = permutateRegex(["a", "b", "c"], { capture: true });
-
-    console.log(regex);
 
     expect("b||c||a".match(regex)?.length).toEqual(2);
     expect("b||c||a".match(regex)?.[1]).toEqual("b||c||a");

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -158,6 +158,58 @@ export function functionRegex(
   return new RegExp(`(${capture ? "" : "?:"}${funcRegEx}|${arrowFuncRegEx})`);
 }
 
+function _permutations(permutation: (string | RegExp)[]) {
+  const permutations: (string | RegExp)[][] = [];
+
+  function permute(array: (string | RegExp)[], length: number) {
+    if (length === 1) {
+      permutations.push(array.slice());
+      return;
+    }
+
+    for (let i = 0; i < length; i++) {
+      permute(array, length - 1);
+      if (length % 2 === 1) {
+        [array[0], array[length - 1]] = [array[length - 1], array[0]];
+      } else {
+        [array[i], array[length - 1]] = [array[length - 1], array[i]];
+      }
+    }
+  }
+
+  permute(permutation, permutation.length);
+  return permutations;
+}
+
+/**
+ * Creates regex matching regular expressions or source strings in any order.
+ * @param {(string | RegExp)[]} regexes
+ * @param {Object} [options]
+ * @param {boolean} [options.capture=false] If `true`, returned regex will be capturing. Defaults to `false`.
+ * @param {string} [options.elementsSeparator=String.raw`\s*\|\|\s*`] Separator added between individual regexes within single permutation. Defaults to `\s*\|\|\s*`.
+ * @param {string} [options.permutationsSeparator='|'] Separator added between different permutations. Defaults to `|`.
+ * @returns {RegExp}
+ */
+
+export function permutateRegex(
+  regexes: (string | RegExp)[],
+  {
+    capture = false,
+    elementsSeparator = String.raw`\s*\|\|\s*`,
+    permutationsSeparator = "|",
+  }: {
+    capture?: boolean;
+    elementsSeparator?: string;
+    permutationsSeparator?: string;
+  } = {}
+): RegExp {
+  const permutations = _permutations(regexes.map((r) => new RegExp(r).source));
+  const source = permutations
+    .map((p) => p.join(elementsSeparator))
+    .join(permutationsSeparator);
+  return new RegExp(`(${capture ? "" : "?:"}${source})`);
+}
+
 export interface ExtendedStyleRule extends CSSStyleRule {
   isDeclaredAfter: (selector: string) => boolean;
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -208,7 +208,7 @@ export function permutateRegex(
     capture?: boolean;
     elementsSeparator?: string;
     permutationsSeparator?: string;
-  } = {}
+  } = {},
 ): RegExp {
   const permutations = _permutations(regexes.map((r) => new RegExp(r).source));
   const source = permutations
@@ -216,7 +216,7 @@ export function permutateRegex(
       p
         .join(elementsSeparator)
         .replace(reCaptureGroupName, String.raw`(?<$1_${index}>`)
-        .replace(reBackreferenceGroupName, String.raw`\k<$1_${index}>`)
+        .replace(reBackreferenceGroupName, String.raw`\k<$1_${index}>`),
     )
     .join(permutationsSeparator);
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -161,6 +161,7 @@ export function functionRegex(
 function _permutations(permutation: (string | RegExp)[]) {
   const permutations: (string | RegExp)[][] = [];
 
+  // Heap's algorithm
   function permute(array: (string | RegExp)[], length: number) {
     if (length === 1) {
       permutations.push(array.slice());


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

- - -
- Helper dealing with regex that should allow specific parts in any order. Ie. for regex composed from parts `a`, `b` and `c`, which checks code written as `a || b || c`, it should match both `a || b || c` and `b || a || c`, and any other permutation.
- Name is a bit rough.
- Default `elementsSeparator` is a bit arbitrarily picked...
- A bit of context https://github.com/freeCodeCamp/freeCodeCamp/pull/53606#issuecomment-1960408047

Capturing groups in individual regex
- It's rather easy to think of situation where it might be handy - ie. `("|')thing\1`, `(?<m>"|")thing\k<m>`. It'd be good to support it.
- If individual regex has capturing group, it will likely break. Named capturing group will surely break - group names have to be unique. Reference to non-named capturing group will reference to the same capturing group from every permutation, so that most likely will also not work as intended.
- What comes to mind is replacing the group reference or name when joining permutations, to ensure their uniqueness and that reference is to the right thing. In such case expecting the capturing group to be named named would make it much easier, than finding/replacing unnamed groups and their numbered references.
- Any ideas?