### PR TITLE
fix: recurse properly when unwinding nested ifs

### DIFF
--- a/python/py_helpers.py
+++ b/python/py_helpers.py
@@ -217,7 +217,7 @@ class Node:
         def _find_bodies(tree):
             if not isinstance(tree, (ast.If, ast.While, ast.For)):
                 return []
-            if self.tree.orelse == []:
+            if tree.orelse == []:
                 return [tree.body]
             if isinstance(tree.orelse[0], (ast.If, ast.While, ast.For)):
                 return [tree.body] + _find_bodies(tree.orelse[0])
@@ -233,7 +233,7 @@ class Node:
             if not isinstance(tree, (ast.If, ast.While)):
                 return []
             test = tree.test
-            if self.tree.orelse == []:
+            if tree.orelse == []:
                 return [test]
             if isinstance(tree.orelse[0], (ast.If, ast.While)):
                 return [test] + _find_conditions(tree.orelse[0])

--- a/python/py_helpers.test.py
+++ b/python/py_helpers.test.py
@@ -708,6 +708,33 @@ while True:
         self.assertTrue(node.find_whiles()[0].find_bodies()[0].find_ifs()[0].find_conditions()[1].is_equivalent("i==1"))
         self.assertIsNone(node.find_whiles()[0].find_bodies()[0].find_ifs()[0].find_conditions()[2].tree)
 
+    def test_find_conditions_nested_ifs(self):
+        code_str = """
+if x > 0:
+  if x == 1:
+    pass
+elif x < 0:
+  if x == -1:
+    pass
+else:
+  if y:
+    return y
+"""
+        node = Node(code_str)
+
+        self.assertTrue(node.find_ifs()[0].find_ifs()[0].find_conditions()[0].is_equivalent("x == 1"))
+        self.assertTrue(node.find_ifs()[0].find_bodies()[1].find_ifs()[0].find_conditions()[0].is_equivalent("x == -1"))
+        
+        # if x: pass
+        # else:
+        #   if y: return y
+        
+        # is equivalent to
+
+        # if x: pass
+        # elif y: return y
+        self.assertTrue(node.find_ifs()[0].find_conditions()[2].is_equivalent("y"))
+        
 
 class TestPassHelpers(unittest.TestCase):
     def test_has_pass(self):

--- a/python/py_helpers.test.py
+++ b/python/py_helpers.test.py
@@ -681,6 +681,16 @@ while True:
         self.assertTrue(node.find_whiles()[0].find_bodies()[0].find_for_loops()[0].find_bodies()[0]
             .find_ifs()[0].find_bodies()[2].is_equivalent("x+=i"))
 
+    def test_find_bodies_nested_ifs(self):
+        code_str = """if x == 1:
+  pass
+elif x == 2:
+  if True:
+    pass"""
+        node = Node(code_str)
+
+        node.find_ifs()[0].find_bodies()[1].is_equivalent("if True:\n  pass")
+
     def test_find_conditions_nested(self):
         code_str = """
 while True:
@@ -710,7 +720,7 @@ else:
     pass
 """
         node = Node(code_str)
-        
+
         self.assertFalse(node.find_ifs()[0].has_pass())
         self.assertTrue(node.find_ifs()[0].find_bodies()[0].has_pass())
         self.assertFalse(node.find_ifs()[0].find_bodies()[1].has_pass())


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

@Dario-DC I can't think of a test for `find_conditions` right now, so if you've got something, please push a commit. If not, don't worry about it. We can keep expanding the coverage if we find more issues! 

<!-- Feel free to add any additional description of changes below this line -->
