### PR TITLE
build: support modern node resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.cjs",
       "default": "./dist/index.mjs"
     }


### PR DESCRIPTION
If tsconfig's moduleResolution is set to Node16 or NodeNext it stops using the "types" property in package.json and, instead, relies on "types" inside "exports".

This now supports both.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
