### PR TITLE
chore: stop editors from trimming fixtures

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,7 @@ insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+# White space is important in code examples so we don't want to trim it
+[lib/__fixtures__/curriculum-helpers-javascript.ts]
+trim_trailing_whitespace = false


### PR DESCRIPTION
The probability that I remember to ctrl + k ctrl + s is roughly 0, so
this saves me a lot of pain.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

https://github.com/freeCodeCamp/curriculum-helpers/pull/190 (which I promise I will review soon!) reminded me that the whitespace trimming is still a nuisance. Hopefully this fixes it.

<!-- Feel free to add any additional description of changes below this line -->
