### PR TITLE
fix: rename syntax errors

### DIFF
--- a/python/py_helpers.py
+++ b/python/py_helpers.py
@@ -460,6 +460,8 @@ def format_exception(*, exception, traceback, filename, new_filename=None):
         _replace_startswith(trace, f'  File "{filename}"', f'  File "{new_filename}"')
         for trace in traces
     ]
-    return build_message(
-        traces=renamed_traces, exception_list=format_exception_only(exception)
-    )
+    renamed_exception = [
+        _replace_startswith(e, f'  File "{filename}"', f'  File "{new_filename}"')
+        for e in format_exception_only(exception)
+    ]
+    return build_message(traces=renamed_traces, exception_list=renamed_exception)

--- a/python/py_helpers.test.py
+++ b/python/py_helpers.test.py
@@ -1552,6 +1552,27 @@ ValueError: This error has no value
             )
             self.assertEqual(formatted_exception, expected_str)
 
+    def test_format_and_rename_syntax_error(self):
+        code = "var ="
+        expected_str = """Traceback (most recent call last):
+  File "main.py", line 1
+    var =
+         ^
+SyntaxError: invalid syntax
+"""
+
+        try:
+            exec(code)
+        except Exception:
+            _last_type, last_value, last_traceback = sys.exc_info()
+            formatted_exception = format_exception(
+                exception=last_value,
+                traceback=last_traceback,
+                filename="<string>",
+                new_filename="main.py",
+            )
+            self.assertEqual(formatted_exception, expected_str)
+
     def test_replaces_only_start_of_line(self):
         code = """
 def nest():


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Updates the error formatter so that it renames the File when there is a syntax error.

Given the code `var=` 

```py
>>> Traceback (most recent call last):
  File "<exec>", line 1
    var=
        ^
SyntaxError: invalid syntax
```

becomes

```pyt
>>> Traceback (most recent call last):
  File "main.py", line 1
    var=
        ^
SyntaxError: invalid syntax
```

<!-- Feel free to add any additional description of changes below this line -->
