### PR TITLE
feat: match functions without knowing the params

### DIFF
--- a/lib/__tests__/curriculum-helper.test.ts
+++ b/lib/__tests__/curriculum-helper.test.ts
@@ -313,6 +313,30 @@ describe("functionRegex", () => {
     expect(match![1]).toBe("let myFunc = (arg1, arg2) => {");
   });
 
+  it("can match unnamed functions with unknown parameters", () => {
+    const code = `function (manner, of, things) {}`;
+    const funcRE = functionRegex(null);
+    expect(funcRE.test(code)).toBe(true);
+  });
+
+  it("can match named functions with unknown parameters", () => {
+    const code = `function all(manner, of, things) {}`;
+    const funcRE = functionRegex("all");
+    expect(funcRE.test(code)).toBe(true);
+  });
+
+  it("can match arrow functions with unknown parameters", () => {
+    const code = `const all = (manner, of, things) => {}`;
+    const funcRE = functionRegex("all");
+    expect(funcRE.test(code)).toBe(true);
+  });
+
+  it("can match anonymous arrow functions with unknown parameters", () => {
+    const code = `(manner, of, things) => {}`;
+    const funcRE = functionRegex(null);
+    expect(funcRE.test(code)).toBe(true);
+  });
+
   it("ignores the body if there are no brackets and it's asked for the closed body", () => {
     const code = `const naomi = (love) => 2 * love;`;
     const funcRE = functionRegex("naomi", ["love"], {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -95,12 +95,12 @@ export function concatRegex(...regexes: (string | RegExp)[]) {
 
 export function functionRegex(
   funcName: string | null,
-  paramList?: string[],
+  paramList?: string[] | null,
   options?: { capture?: boolean; includeBody?: boolean }
 ): RegExp {
   const capture = options?.capture ?? false;
   const includeBody = options?.includeBody ?? true;
-  const params = (paramList ?? []).join("\\s*,\\s*");
+  const params = paramList ? paramList.join("\\s*,\\s*") : "[^)]*";
 
   const normalFunctionName = funcName ? "\\s" + escapeRegExp(funcName) : "";
   const arrowFunctionName = funcName


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Use case:

```js
const sum = xs.reduce(
  (accumulator, currentValue) => accumulator + currentValue, 0
);
```
If you want to just check that the callback exists, `functionRegex` should not care about the arguments. 

In the main repo, the third test of:

https://github.com/freeCodeCamp/freeCodeCamp/blob/main/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-oop-by-building-a-shopping-cart/63eedebb0ec0231ff1cede1a.md



<!-- Feel free to add any additional description of changes below this line -->
