### PR TITLE
feat: add html element extractor

### DIFF
--- a/lib/__fixtures__/curriculum-helpers-html.ts
+++ b/lib/__fixtures__/curriculum-helpers-html.ts
@@ -22,9 +22,25 @@ not a comment
 not a comment
 `;
 
+const htmlExampleHead = `
+<link rel="stylesheet" href="styles.css">
+<head>
+  <meta charset="UTF-8" />
+  <title>Piano</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>`;
+
+const htmlInnerExample = `
+  <meta charset="UTF-8" />
+  <title>Piano</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+`;
+
 const testValues = {
   htmlFullExample,
   htmlCodeWithCommentsRemoved,
+  htmlExampleHead,
+  htmlInnerExample,
 };
 
 export default testValues;

--- a/lib/__tests__/curriculum-helper.test.ts
+++ b/lib/__tests__/curriculum-helper.test.ts
@@ -9,7 +9,12 @@ const { stringWithWhiteSpaceChars, stringWithWhiteSpaceCharsRemoved } =
 
 const { cssFullExample, cssCodeWithCommentsRemoved } = cssTestValues;
 
-const { htmlFullExample, htmlCodeWithCommentsRemoved } = htmlTestValues;
+const {
+  htmlFullExample,
+  htmlCodeWithCommentsRemoved,
+  htmlExampleHead,
+  htmlInnerExample,
+} = htmlTestValues;
 
 const {
   jsCodeWithSingleAndMultLineComments,
@@ -86,6 +91,16 @@ describe("removeHtmlComments", () => {
     expect(removeHtmlComments(htmlFullExample)).toBe(
       htmlCodeWithCommentsRemoved
     );
+  });
+});
+
+describe("extractHTMLElement", () => {
+  const { extractHTMLElement } = helper;
+  it("returns an empty string if no head is found", () => {
+    expect(typeof extractHTMLElement("", "head")).toBe("string");
+  });
+  it("returns inner HTML string if a head is present", () => {
+    expect(extractHTMLElement(htmlExampleHead, "head")).toBe(htmlInnerExample);
   });
 });
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -12,6 +12,20 @@ export function removeHtmlComments(str: string): string {
 }
 
 /**
+ * Extracts the inner html of every element inside the head
+ * @param {String} code a HTML string of the head
+ * @returns {String} the inner html of every element in the head or an empty string if no head is found
+ */
+
+export function extractHTMLElement(code: string, tag: string = "head"): string {
+  const expression = new RegExp(
+    "(?<=<" + tag + "\\s*>)(?:.|\\s*)*?(?=<\\/" + tag + "\\s*>)"
+  );
+  console.log(expression.source);
+  return code.match(expression)?.toString() ?? "";
+}
+
+/**
  * Removes every CSS-comment from the string that is provided
  * @param {String} str a CSS-string where the comments need to be removed of
  * @returns {String}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
A variation of this particular regex was used in PRs like https://github.com/freeCodeCamp/freeCodeCamp/pull/55547. I expect this kind of thing to come up a little bit more often in the future which is why I'm adding it to your curriculum helpers. I've also generalized this in an attempt to increase the usefulness. Though without that extra parameter present it will just extract head elements. 