### PR TITLE
chore: capture destructured parameters

### DIFF
--- a/lib/__fixtures__/curriculum-helpers-javascript.ts
+++ b/lib/__fixtures__/curriculum-helpers-javascript.ts
@@ -65,6 +65,8 @@ const letFunction =
 
 const arrowFunction = `const myFunc = name => console.log("Name")`;
 
+const destructuredArgsFunctionDeclaration = `function printFruits({a, b},c = 1, ...rest) {`;
+
 const testValues = {
   jsCodeWithSingleAndMultLineComments,
   jsCodeWithSingleAndMultLineCommentsRemoved,
@@ -78,6 +80,7 @@ const testValues = {
   constFunction,
   letFunction,
   arrowFunction,
+  destructuredArgsFunctionDeclaration,
 };
 
 export default testValues;

--- a/lib/__tests__/javascript-helper.test.ts
+++ b/lib/__tests__/javascript-helper.test.ts
@@ -2,8 +2,13 @@ import jsTestValues from "../__fixtures__/curriculum-helpers-javascript";
 
 import { getFunctionParams } from "../index";
 
-const { functionDeclaration, constFunction, letFunction, arrowFunction } =
-  jsTestValues;
+const {
+  functionDeclaration,
+  constFunction,
+  letFunction,
+  arrowFunction,
+  destructuredArgsFunctionDeclaration,
+} = jsTestValues;
 
 describe("js-help", () => {
   describe("getFunctionArgs", () => {
@@ -31,6 +36,14 @@ describe("js-help", () => {
     it("gets arguments from arrow functions", function () {
       const parameters = getFunctionParams(arrowFunction);
       expect(parameters[0].name).toBe("name");
+    });
+    it("gets arguments from a destructured function declaration", function () {
+      const parameters = getFunctionParams(destructuredArgsFunctionDeclaration);
+      expect(parameters[0].name).toBe("a");
+      expect(parameters[1].name).toBe("b");
+      expect(parameters[2].name).toBe("c");
+      expect(parameters[2].defaultValue).toBe("1");
+      expect(parameters[3].name).toBe("...rest");
     });
   });
 });

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -425,7 +425,8 @@ export class CSSHelp {
 /**
  * Extracts all function parameters and default values from a function
  * @param functionObject A function in string form
- * @returns {{name:String,defaultValue: String | undefined}}
+ * Note: All number parameters will returned as a string,
+ * @returns {{name:string,defaultValue: string | undefined}}
  */
 export function getFunctionParams(code: string) {
   // Regular expression to match function declarations, arrow functions, and function expressions
@@ -447,18 +448,22 @@ export function getFunctionParams(code: string) {
     const paramString =
       paramMatch[1] || paramMatch[2] || paramMatch[3] || paramMatch[4];
     // Split the parameter string by commas to get individual parameters
-    const params = paramString.split(",").map((param: string) => {
-      // Split each parameter by '=' to separate name and default value
-      const parts = param.trim().split("=");
-      // If the parameter has a default value, extract it, otherwise set it to undefined
-      const defaultValue =
-        parts.length > 1 ? parts[1].replace(/['"]/g, "").trim() : undefined;
-      // Return an object with the parameter name and default value
-      return {
-        name: parts[0].trim(),
-        defaultValue: defaultValue,
-      };
-    });
+    const params = paramString
+      .replace(/[{}[\]]/g, "")
+      .split(",")
+      .map((param: string) => {
+        // Split each parameter by '=' to separate name and default value
+        const parts = param.trim().split(/[=]/);
+        // If the parameter has a default value, extract it, otherwise set it to undefined
+        const defaultValue =
+          parts.length > 1 ? parts[1].replace(/['"]/g, "").trim() : undefined;
+
+        // Return an object with the parameter name and default value
+        return {
+          name: parts[0].trim(),
+          defaultValue: defaultValue,
+        };
+      });
     return params;
   }
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #247

<!-- Feel free to add any additional description of changes below this line -->
Parameters that are passed in that are de-structured are being read as if they were single variables. Additionally spread variables deserve to be read if they're using the spread operator. 