### PR TITLE
chore: fix misspelling in comment on selectorsFromSelector

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -383,7 +383,7 @@ export class CSSHelp {
     return Array.from(styleSheet?.cssRules || []);
   }
 
-  // Takes a CSS selector, returns all equivelant selectors from the current document
+  // Takes a CSS selector, returns all equivalent selectors from the current document
   // or an empty array if there are no matches
   selectorsFromSelector(selector: string): string[] {
     const elements = this.doc.querySelectorAll(selector);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
I found this typo and had to fix it. 