### PR TITLE
fix: use valid regex syntax

### DIFF
--- a/lib/__tests__/curriculum-helper.test.tsx
+++ b/lib/__tests__/curriculum-helper.test.tsx
@@ -104,7 +104,7 @@ describe("removeJSComments", () => {
     expect(removeJSComments(code)).toBe("");
   });
 
-  it('should ignore comments inside multiline template strings', () => {
+  it("should ignore comments inside multiline template strings", () => {
     const expected = `const foo = \`// this is a comment
 * me too */\`;
 const bar = \`// this is a comment
@@ -113,26 +113,24 @@ const bar = \`// this is a comment
     const actual = removeJSComments(expected);
 
     expect(actual).toBe(expected);
-  })
+  });
 
-
-  it('should handle comments that end in a slash', () => {
+  it("should handle comments that end in a slash", () => {
     const expected = `const bar = \`// this is a comment \\
 \`;`;
     const actual = removeJSComments(expected);
 
     expect(actual).toBe(expected);
-  })
+  });
 
-
-  it('should strip comments with quotes', () => {
+  it("should strip comments with quotes", () => {
     const expected = '\nconst foo = "bar";\n';
     const actual = removeJSComments(`// this is a comment with "quotes"
 const foo = "bar";
 `);
 
     expect(actual).toBe(expected);
-  })
+  });
 
   it("leaves malformed JS unchanged", () => {
     const actual = "/ unclosed regex";

--- a/lib/__tests__/curriculum-helper.test.tsx
+++ b/lib/__tests__/curriculum-helper.test.tsx
@@ -99,6 +99,41 @@ describe("removeJSComments", () => {
     );
   });
 
+  it("handles nested comments", () => {
+    const code = `/* this is a comment /* nested comment */ */`;
+    expect(removeJSComments(code)).toBe("");
+  });
+
+  it('should ignore comments inside multiline template strings', () => {
+    const expected = `const foo = \`// this is a comment
+* me too */\`;
+const bar = \`// this is a comment
+/* me too */\`;
+`;
+    const actual = removeJSComments(expected);
+
+    expect(actual).toBe(expected);
+  })
+
+
+  it('should handle comments that end in a slash', () => {
+    const expected = `const bar = \`// this is a comment \\
+\`;`;
+    const actual = removeJSComments(expected);
+
+    expect(actual).toBe(expected);
+  })
+
+
+  it('should strip comments with quotes', () => {
+    const expected = '\nconst foo = "bar";\n';
+    const actual = removeJSComments(`// this is a comment with "quotes"
+const foo = "bar";
+`);
+
+    expect(actual).toBe(expected);
+  })
+
   it("leaves malformed JS unchanged", () => {
     const actual = "/ unclosed regex";
     expect(removeJSComments(actual)).toBe(actual);

--- a/lib/parse.ts
+++ b/lib/parse.ts
@@ -6,7 +6,10 @@ import { languages } from "./languages";
 
 const constants = {
   ESCAPED_CHAR_REGEX: /^\\./,
-  QUOTED_STRING_REGEX: /^(['"`])((?:\\\1|[^\1])*?)(\1)/,
+  // The QUOTED_STRING_REGEX looks for an opening quote, then any number of
+  // escaped quotes or characters that are not the opening quote. Finally, it
+  // looks for the closing quote.
+  QUOTED_STRING_REGEX: /^([`'"])((?:\\\1|(?!\1).)*)\1/s,
   NEWLINE_REGEX: /^\r*\n/,
 };
 
@@ -89,8 +92,7 @@ export const parse = (input: string, options: Partial<options> = {}) => {
    * Parse input string
    */
 
-  // TODO: This value isn't modified according to eslint
-  /* eslint-disable-next-line */
+  // eslint-disable-next-line no-unmodified-loop-condition
   while (remaining !== "") {
     // Escaped characters
     if ((token = scan(constants.ESCAPED_CHAR_REGEX, "text"))) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
   "include": ["lib/", "declarations.d.ts", "dist/declarations.d.ts", "python/"],
   "compilerOptions": {
     "module": "ES6",
-    "target": "ES6",
+    "target": "ES2018",
     "outDir": "./dist",
     "sourceMap": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

`/(")[^\1]` Is not, it seems, a valid regex. The idea was that `[^\1]` should be "not the first backreference", however backreferences cannot be used in character classes. Except, obviously, this has been working just fine.

Regardless of the root cause, the new regex is definitely valid and so should be fine.

Ref: https://github.com/freeCodeCamp/curriculum-helpers/pull/146#issuecomment-2394038533

<!-- Feel free to add any additional description of changes below this line -->
