### PR TITLE
feat: add a helper to find if a function has a func/method call

### DIFF
--- a/python/py_helpers.py
+++ b/python/py_helpers.py
@@ -224,6 +224,19 @@ class Node:
     def has_call(self, call):
         return any(node.is_equivalent(call) for node in self._find_all(ast.Expr))
 
+    def func_has_call(self, function, name):
+        body = self.find_function(function).find_body()
+        if body:
+            for node in ast.walk(body.tree):
+                fields = node._fields
+                for n, field in enumerate(fields):
+                    if field == "attr" or field == "id" and fields[n + 1] == "ctx":
+                        if getattr(node, field, None) == name and isinstance(
+                            getattr(node, fields[n + 1], None), ast.Load
+                        ):
+                            return True
+        return False
+
     def find_call_args(self):
         if not isinstance(self.tree, ast.Call):
             return []

--- a/python/py_helpers.py
+++ b/python/py_helpers.py
@@ -224,8 +224,8 @@ class Node:
     def has_call(self, call):
         return any(node.is_equivalent(call) for node in self._find_all(ast.Expr))
 
-    def func_has_call(self, function, name):
-        body = self.find_function(function).find_body()
+    def block_has_call(self, name, function=None):
+        body = self if function is None else self.find_function(function).find_body()
         if body:
             for node in ast.walk(body.tree):
                 fields = node._fields

--- a/python/py_helpers.test.py
+++ b/python/py_helpers.test.py
@@ -391,7 +391,7 @@ obj.foo("spam")
         self.assertTrue(node.has_call("int('1')"))
         self.assertTrue(node.has_call("obj.foo('spam')"))
 
-    def test_func_has_call(self):
+    def test_block_has_call(self):
         code_str = """
 
 srt = sorted([5, 1, 9])
@@ -408,11 +408,15 @@ def eggs(dictionary):
 """
         node = Node(code_str)
 
-        self.assertFalse(node.func_has_call("srt", "sorted"))
-        self.assertTrue(node.func_has_call("foo", "sorted"))
-        self.assertTrue(node.func_has_call("spam", "sort"))
-        self.assertTrue(node.func_has_call("eggs", "get"))
-        self.assertFalse(node.func_has_call("func", "sort"))
+        self.assertFalse(node.block_has_call("sorted", "srt"))
+        self.assertTrue(node.block_has_call("sorted", "foo"))
+        self.assertTrue(node.block_has_call("sorted"))
+        self.assertTrue(node.block_has_call("sort", "spam"))
+        self.assertFalse(node.block_has_call("sort", "func"))
+        self.assertTrue(node.block_has_call("sort"))
+        self.assertTrue(node.block_has_call("get", "eggs"))
+        self.assertTrue(node.block_has_call("get"))
+        self.assertFalse(node.block_has_call("split"))
 
     def test_has_class(self):
         class_str = """

--- a/python/py_helpers.test.py
+++ b/python/py_helpers.test.py
@@ -395,6 +395,9 @@ obj.foo("spam")
         code_str = """
 
 srt = sorted([5, 1, 9])
+
+def foo(lst):
+  return sorted(lst)
         
 def spam(lst):
   return lst.sort()
@@ -405,9 +408,10 @@ def eggs(dictionary):
 """
         node = Node(code_str)
 
+        self.assertFalse(node.func_has_call("srt", "sorted"))
+        self.assertTrue(node.func_has_call("foo", "sorted"))
         self.assertTrue(node.func_has_call("spam", "sort"))
         self.assertTrue(node.func_has_call("eggs", "get"))
-        self.assertFalse(node.func_has_call("srt", "sorted"))
         self.assertFalse(node.func_has_call("func", "sort"))
 
     def test_has_class(self):

--- a/python/py_helpers.test.py
+++ b/python/py_helpers.test.py
@@ -391,6 +391,25 @@ obj.foo("spam")
         self.assertTrue(node.has_call("int('1')"))
         self.assertTrue(node.has_call("obj.foo('spam')"))
 
+    def test_func_has_call(self):
+        code_str = """
+
+srt = sorted([5, 1, 9])
+        
+def spam(lst):
+  return lst.sort()
+
+def eggs(dictionary):
+  if True:
+    k = dictionary.get(key)
+"""
+        node = Node(code_str)
+
+        self.assertTrue(node.func_has_call("spam", "sort"))
+        self.assertTrue(node.func_has_call("eggs", "get"))
+        self.assertFalse(node.func_has_call("srt", "sorted"))
+        self.assertFalse(node.func_has_call("func", "sort"))
+
     def test_has_class(self):
         class_str = """
 class Foo:


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

The main purpose of this helper would be to verify that specific built-in functions or methods (such as `.sort()` or `sorted()`) are not used by campers to solve DSA labs.

Not sure if we need it, but you can either choose to check that the method/function `spam` is called anywhere within a specific function `foo` with:

```py
_Node(_code).block_has_call(spam, foo)
```
or verify that `spam` is called anywhere within the user's code:

```py
_Node(_code).block_has_call(spam)
```
