### PR TITLE
test: only watch .ts files, trigger related tests

### DIFF
--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,5 +1,10 @@
 import { configDefaults, defineConfig } from "vitest/config";
 
+const integrationTests = [
+  "./packages/main/integration-tests/index.test.ts",
+  "./packages/main/integration-tests/timeout.test.ts",
+];
+
 export default defineConfig({
   assetsInclude: ["**/*.py"],
   test: {
@@ -9,13 +14,17 @@ export default defineConfig({
     globalSetup: "vitest-environment-puppeteer/global-init",
     watchTriggerPatterns: [
       {
-        pattern: /packages/,
-        testsToRun: (id, match) => {
-          // In principle any source change could impact the integration tests,
-          return [
-            `./packages/main/integration-tests/index.test.ts`,
-            `./packages/main/integration-tests/timeout.test.ts`,
-          ];
+        pattern: /packages.*\.ts$/,
+        testsToRun: (id) => {
+          // If the changed file is a test, it's the only test that could be
+          // affected.
+          const isTestFile = id.endsWith(".test.ts");
+          if (isTestFile) return id;
+
+          // Otherwise, if there is a test file, this is it:
+          const testFile = id.slice(0, -3) + ".test.ts";
+          // In principle any source change could impact the integration tests
+          return [...integrationTests, testFile];
         },
       },
     ],


### PR DESCRIPTION
All unit tests follow the pattern filename.ts -> filename.test.ts, so vitest now always looks for the related test.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
