### PR TITLE
feat: make all evaluators handle before hooks

### DIFF
--- a/packages/dom-evaluator/src/dom-test-evaluator.ts
+++ b/packages/dom-evaluator/src/dom-test-evaluator.ts
@@ -31,7 +31,7 @@ export interface InitTestFrameOptions {
   };
   loadEnzyme?: boolean;
   hooks?: {
-    beforeAll?: string;
+    beforeEach?: string;
   };
 }
 
@@ -131,7 +131,8 @@ export class DOMTestEvaluator implements TestEvaluator {
         // This return can be a function
         // i.e. function() { assert(true, 'happy coding'); }
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const test = await eval(testString);
+        const test = await eval(`${opts.hooks?.beforeEach ?? ""}
+${testString}`);
         if (typeof test === "function") {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-call
           await test();

--- a/packages/javascript-evaluator/src/javascript-test-evaluator.ts
+++ b/packages/javascript-evaluator/src/javascript-test-evaluator.ts
@@ -61,7 +61,8 @@ export class JavascriptTestEvaluator implements TestEvaluator {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const editableContents = opts.code?.editableContents ?? "";
         try {
-          await eval(`${opts.source};
+          await eval(`${opts.hooks?.beforeEach ?? ""}
+${opts.source};
 __userCodeWasExecuted = true;
 ${test};`);
         } catch (err) {

--- a/packages/javascript-evaluator/src/javascript-test-evaluator.ts
+++ b/packages/javascript-evaluator/src/javascript-test-evaluator.ts
@@ -49,6 +49,8 @@ export class JavascriptTestEvaluator implements TestEvaluator {
   }
 
   init(opts: InitWorkerOptions) {
+    eval(opts.hooks?.beforeAll ?? "");
+
     this.#runTest = async (rawTest) => {
       this.#proxyConsole.on();
       const test = wrapCode(rawTest);

--- a/packages/main/integration-tests/index.test.ts
+++ b/packages/main/integration-tests/index.test.ts
@@ -253,7 +253,7 @@ describe("Test Runner", () => {
     });
   });
 
-  describe.only.each([
+  describe.each([
     {
       type: "dom",
       hooks: { beforeAll: "const x = 1;" },
@@ -292,7 +292,7 @@ describe("Test Runner", () => {
     });
   });
 
-  describe.only.each([
+  describe.each([
     { type: "dom" },
     // FakeTimers to come later
     // {

--- a/packages/main/integration-tests/index.test.ts
+++ b/packages/main/integration-tests/index.test.ts
@@ -1120,6 +1120,20 @@ second = input()
       expect(result).toEqual({ pass: true });
     });
 
+    it("should have access to runPython in the beforeEach hook", async () => {
+      const result = await page.evaluate(async () => {
+        const runner = window.FCCTestRunner.getRunner("python");
+        await runner?.init({
+          hooks: {
+            beforeEach: "assert.equal(runPython('1 + 1'), 2)",
+          },
+        });
+        return runner?.runTest("");
+      });
+
+      expect(result).toEqual({ pass: true });
+    });
+
     it("should return error types if the python code raises an exception", async () => {
       const result = await page.evaluate(async () => {
         const runner = window.FCCTestRunner.getRunner("python");

--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -48,6 +48,7 @@ export class FCCTestRunner {
     code?: { contents?: string; editableContents?: string };
     hooks?: {
       beforeAll?: string;
+      beforeEach?: string;
     };
     loadEnzyme?: boolean;
   }) {

--- a/packages/main/src/test-runner.ts
+++ b/packages/main/src/test-runner.ts
@@ -54,6 +54,7 @@ type InitOptions = {
   };
   hooks?: {
     beforeAll?: string;
+    beforeEach?: string;
   };
 };
 

--- a/packages/python-evaluator/src/python-test-evaluator.ts
+++ b/packages/python-evaluator/src/python-test-evaluator.ts
@@ -126,6 +126,8 @@ class PythonTestEvaluator implements TestEvaluator {
 			_code = f.read()
 		`);
 
+        eval(opts.hooks?.beforeEach ?? "");
+
         // Evaluates the learner's code so that any variables they define are
         // available to the test.
         runPython(opts.source ?? "");

--- a/packages/shared/src/interfaces/test-evaluator.ts
+++ b/packages/shared/src/interfaces/test-evaluator.ts
@@ -43,6 +43,9 @@ export interface InitWorkerOptions {
     editableContents?: string;
   };
   source?: string;
+  hooks?: {
+    beforeEach?: string;
+  };
 }
 
 export interface TestEvaluator {

--- a/packages/shared/src/interfaces/test-evaluator.ts
+++ b/packages/shared/src/interfaces/test-evaluator.ts
@@ -45,6 +45,7 @@ export interface InitWorkerOptions {
   source?: string;
   hooks?: {
     beforeEach?: string;
+    beforeAll?: string;
   };
 }
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The DOM evaluator shares state between tests, so a `beforeAll` hook is necessary for anything that needs to be setup just once. Using `beforeAll` for worker evaluators (JS and Python) is less vital since they have more isolated tests.  However, there are ways to get around the isolation. For example, the virtual filesystem that pyodide gives access to is persisted between tests, as is the `globalThis` object.

With that in mind, this makes all the evaluators handle both `beforeEach` and `beforeAll`.

<!-- Feel free to add any additional description of changes below this line -->
