### PR TITLE
feat: use function constructor (JS + DOM)

### DIFF
--- a/packages/dom-evaluator/src/dom-test-evaluator.test.ts
+++ b/packages/dom-evaluator/src/dom-test-evaluator.test.ts
@@ -85,7 +85,7 @@ describe("DOMTestEvaluator", () => {
     });
 
     it("should await tests that return promises", async () => {
-      const test = `new Promise((resolve) => setTimeout(resolve, 1))
+      const test = `await new Promise((resolve) => setTimeout(resolve, 1))
 			  .then(() => { assert.equal(1,2)});`;
 
       const result = await evaluator.runTest(test);

--- a/packages/javascript-evaluator/src/javascript-test-evaluator.test.ts
+++ b/packages/javascript-evaluator/src/javascript-test-evaluator.test.ts
@@ -144,7 +144,7 @@ const x = 1;
 
     // This is probably behavior we want, but it's not how the client works at
     // the moment.
-    it.fails("should NOT handle async sources (yet)", async () => {
+    it("should handle async sources", async () => {
       evaluator.init({
         code: {},
         source: `let delay = () => new Promise((resolve) => setTimeout(resolve, 10));

--- a/packages/main/integration-tests/index.test.ts
+++ b/packages/main/integration-tests/index.test.ts
@@ -683,7 +683,7 @@ const getFive = () => 5;
           type: "dom",
         });
         return runner.runTest(
-          "async () => await document.getElementById('audio').play()",
+          "await document.getElementById('audio').play()",
         );
       }, source);
 

--- a/packages/shared/src/test-with-scope.ts
+++ b/packages/shared/src/test-with-scope.ts
@@ -1,0 +1,11 @@
+const AsyncFunction = async function () {}.constructor as FunctionConstructor;
+
+export async function evalWithScope(
+  code: string,
+  scope: Record<string, unknown>,
+): Promise<void> {
+  const testFn = new AsyncFunction(...Object.keys(scope), code);
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+  await testFn(...Object.values(scope));
+}


### PR DESCRIPTION
The function constructor modularize the code a little, since it's now
possible to create a scope for the evaluation separately from the eval
call. The previous implementation had to declare variables in the
surrounding scope.

There is a breaking change because the function returns nothing. This is
in contrast to eval with returned the last call. As a result all the
tests that were "returning" (i.e. had as their last call) a function,
will need to inline that function.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ ] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
