### PR TITLE
feat: change python testString format to match the rest

### DIFF
--- a/packages/main/integration-tests/timeout.test.ts
+++ b/packages/main/integration-tests/timeout.test.ts
@@ -93,9 +93,7 @@ def run():
           source,
         });
         const result = await runner?.runTest(
-          `({
-						test: () => assert.equal(runPython('loop()'), 1)
-				})`,
+          `assert.equal(runPython('loop()'), 1)`,
           10,
         );
         return result;
@@ -104,9 +102,7 @@ def run():
       const result = await page.evaluate(async () => {
         const runner = window.FCCTestRunner.getRunner("python");
         return runner?.runTest(
-          `({
-						test: () => assert.equal(runPython('run()'), 1)
-				})`,
+          `assert.equal(runPython('run()'), 1)`,
         );
       });
 
@@ -134,9 +130,7 @@ while True:
           source,
         });
         return runner?.runTest(
-          `({
-						test: () => assert.equal(runPython('1'), 1)
-				})`,
+          `assert.equal(runPython('1'), 1)`,
           10,
         );
       }, source);


### PR DESCRIPTION
i.e. no more ({ test: () => {// the test}}), now it's just // the test

This is in draft until I can test this properly against the main repo's challenges.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
