### PR TITLE
fix: log value of object when logged even if it changes

### DIFF
--- a/packages/tests/integration-tests/index.test.ts
+++ b/packages/tests/integration-tests/index.test.ts
@@ -216,6 +216,30 @@ describe("Test Runner", () => {
       });
     });
 
+    it("should evaluate the logged value at the time it was logged", async () => {
+      const result = await page.evaluate(async (type) => {
+        const runner = await window.FCCTestRunner.createTestRunner({
+          type,
+        });
+        return runner.runTest(`
+const arr = [];
+for(let i = 0; i < 3; i++) {
+  console.log(arr);
+  arr.push(i);
+}
+`);
+      }, type);
+
+      expect(result).toEqual({
+        pass: true,
+        logs: [
+          { level: "log", msg: "[]" },
+          { level: "log", msg: "[ 0 ]" },
+          { level: "log", msg: "[ 0, 1 ]" },
+        ],
+      });
+    });
+
     it("should console.error non-chai errors thrown in the test", async () => {
       const spy = vi.fn();
       page.once("console", (msg) => {

--- a/packages/tests/proxy-console.test.ts
+++ b/packages/tests/proxy-console.test.ts
@@ -8,6 +8,8 @@ const levelsForEach = LEVELS.map((level) => ({
   level,
 }));
 
+const simpleFormat = (x: string) => x;
+
 describe("proxy-console", () => {
   let originalConsole: typeof console;
   beforeAll(() => {
@@ -24,7 +26,7 @@ describe("proxy-console", () => {
   });
 
   it("should replace console methods when .on is called", () => {
-    const proxy = new ProxyConsole(window.console);
+    const proxy = new ProxyConsole(window.console, simpleFormat);
 
     proxy.on();
 
@@ -34,7 +36,7 @@ describe("proxy-console", () => {
   });
 
   it("should restore console methods when .off is called", () => {
-    const proxy = new ProxyConsole(window.console);
+    const proxy = new ProxyConsole(window.console, simpleFormat);
 
     proxy.on();
     proxy.off();
@@ -50,7 +52,7 @@ describe("proxy-console", () => {
       const logSpy = vi
         .spyOn(window.console, level)
         .mockImplementation(vi.fn());
-      const proxy = new ProxyConsole(window.console);
+      const proxy = new ProxyConsole(window.console, simpleFormat);
 
       proxy.on();
       window.console[level]("test message");
@@ -60,41 +62,41 @@ describe("proxy-console", () => {
   );
 
   describe("flush", () => {
-    it("should return an empty array if no calls were recorded", () => {
-      const proxy = new ProxyConsole(window.console);
+    it("should not have a logs property if no calls were recorded", () => {
+      const proxy = new ProxyConsole(window.console, simpleFormat);
 
       proxy.on();
       const results = proxy.flush();
 
-      expect(results).toEqual([]);
+      expect(results).toEqual({});
     });
 
     it("should return all the calls recorded while proxying", () => {
       vi.spyOn(window.console, "log").mockImplementation(vi.fn());
       vi.spyOn(window.console, "warn").mockImplementation(vi.fn());
-      const proxy = new ProxyConsole(window.console);
+      const proxy = new ProxyConsole(window.console, simpleFormat);
       proxy.on();
 
       window.console.log("test message 1");
       window.console.warn("test message 2");
       const results = proxy.flush();
 
-      expect(results).toEqual([
-        { level: "log", args: ["test message 1"] },
-        { level: "warn", args: ["test message 2"] },
+      expect(results.logs).toEqual([
+        { level: "log", msg: "test message 1" },
+        { level: "warn", msg: "test message 2" },
       ]);
     });
 
     it("should clear the calls after flushing", () => {
       vi.spyOn(window.console, "log").mockImplementation(vi.fn());
-      const proxy = new ProxyConsole(window.console);
+      const proxy = new ProxyConsole(window.console, simpleFormat);
       proxy.on();
 
       window.console.log("test message 1");
       proxy.flush();
       const results = proxy.flush();
 
-      expect(results).toEqual([]);
+      expect(results).toEqual({});
     });
   });
 });


### PR DESCRIPTION
e.g.

```js
xs = []
console.log(xs)
xs.push(1)
console.log(xs)
```

should log
```
[], [ 1 ]
```
not
```
[ 1 ], [ 1 ]
```

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
