### PR TITLE
fix: use concurrently to give correct watch behaviour

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@types/chai": "^4.3.20",
     "@typescript-eslint/eslint-plugin": "^8.31.0",
     "@typescript-eslint/parser": "^8.31.0",
+    "concurrently": "^9.2.0",
     "eslint": "9.30.1",
     "eslint-config-prettier": "10.1.5",
     "eslint-config-xo": "0.46.0",
@@ -54,7 +55,7 @@
     "ts-loader": "9.5.2",
     "typescript": "^5.8.2",
     "typescript-eslint": "^8.31.0",
-    "vitest": "^3.1.4",
+    "vitest": "^3.2.4",
     "webpack": "5.99.9",
     "webpack-cli": "5.1.4"
   },
@@ -93,6 +94,9 @@
     "lint": "eslint . --max-warnings 0 && prettier --check . && tsc --build",
     "format": "prettier --write .",
     "test": "vitest",
+    "test:watch": "concurrently --prefix none \"pnpm test:unit --watch\" \"pnpm test:integration --watch\"",
+    "test:unit": "vitest --config vitest.unit.config.mjs",
+    "test:integration": "vitest --config vitest.integration.config.mjs",
     "prepare": "husky install",
     "prepublishOnly": "pnpm clean:build && pnpm build",
     "webpack": "webpack"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^8.31.0
         version: 8.35.1(eslint@9.30.1)(typescript@5.8.3)
+      concurrently:
+        specifier: ^9.2.0
+        version: 9.2.0
       eslint:
         specifier: 9.30.1
         version: 9.30.1
@@ -124,7 +127,7 @@ importers:
         specifier: ^8.31.0
         version: 8.35.1(eslint@9.30.1)(typescript@5.8.3)
       vitest:
-        specifier: ^3.1.4
+        specifier: ^3.2.4
         version: 3.2.4(@types/node@24.0.10)(jsdom@20.0.3)(terser@5.39.0)(yaml@2.8.0)
       webpack:
         specifier: 5.99.9
@@ -1756,6 +1759,11 @@ packages:
   concat-stream@1.6.2:
     resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
     engines: {'0': node >= 0.8}
+
+  concurrently@9.2.0:
+    resolution: {integrity: sha512-IsB/fiXTupmagMW4MNp2lx2cdSN2FfZq78vF90LBB+zZHArbIQZjQtzXCiXnvTxCZSvXanTqFLWBjw2UkLx1SQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   confusing-browser-globals@1.0.11:
     resolution: {integrity: sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==}
@@ -6029,6 +6037,16 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 2.3.8
       typedarray: 0.0.6
+
+  concurrently@9.2.0:
+    dependencies:
+      chalk: 4.1.2
+      lodash: 4.17.21
+      rxjs: 7.8.2
+      shell-quote: 1.8.2
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
 
   confusing-browser-globals@1.0.11: {}
 

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,32 +1,7 @@
-import { configDefaults, defineConfig } from "vitest/config";
-
-const integrationTests = [
-  "./packages/main/integration-tests/index.test.ts",
-  "./packages/main/integration-tests/timeout.test.ts",
-];
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-  assetsInclude: ["**/*.py"],
   test: {
-    environment: "puppeteer",
-    exclude: [...configDefaults.exclude, "packages/*/build", "dist"],
-    globals: true, // TODO: remove this OR include vitest types
-    globalSetup: "vitest-environment-puppeteer/global-init",
-    watchTriggerPatterns: [
-      {
-        pattern: /packages.*\.ts$/,
-        testsToRun: (id) => {
-          // If the changed file is a test, it's the only test that could be
-          // affected.
-          const isTestFile = id.endsWith(".test.ts");
-          if (isTestFile) return id;
-
-          // Otherwise, if there is a test file, this is it:
-          const testFile = id.slice(0, -3) + ".test.ts";
-          // In principle any source change could impact the integration tests
-          return [...integrationTests, testFile];
-        },
-      },
-    ],
+    projects: ["./vitest.integration.config.mjs", "./vitest.unit.config.mjs"],
   },
 });

--- a/vitest.integration.config.mjs
+++ b/vitest.integration.config.mjs
@@ -1,0 +1,26 @@
+import { configDefaults, defineConfig } from "vitest/config";
+
+const integrationTests = [
+  "./packages/tests/integration-tests/index.test.ts",
+  "./packages/tests/integration-tests/timeout.test.ts",
+];
+
+export default defineConfig({
+  test: {
+    watchTriggerPatterns: [
+      {
+        pattern: /packages\/.*\/.*\.ts$/,
+        testsToRun: () => {
+          // Any source change could impact the integration tests
+          return integrationTests;
+        },
+      },
+    ],
+    name: "integration",
+    globals: true, // TODO: remove this OR include vitest types
+    environment: "puppeteer",
+    include: integrationTests,
+    exclude: [...configDefaults.exclude, "packages/*/build", "dist"],
+    globalSetup: "vitest-environment-puppeteer/global-init",
+  },
+});

--- a/vitest.unit.config.mjs
+++ b/vitest.unit.config.mjs
@@ -1,0 +1,16 @@
+import { configDefaults, defineConfig } from "vitest/config";
+
+export default defineConfig({
+  assetsInclude: ["**/*.py"],
+  test: {
+    name: "unit",
+    globals: true, // TODO: remove this OR include vitest types
+    include: ["**/*.test.ts", "**/*.test.tsx"],
+    exclude: [
+      ...configDefaults.exclude,
+      "packages/*/build",
+      "dist",
+      "packages/tests/integration-tests",
+    ],
+  },
+});


### PR DESCRIPTION
Vitest has projects which are a great way to organise test config, but watchTriggerPatterns is global, not per project. If you want a single project to behave like e2e tests (i.e. run if the source changes) and another like unit tests (i.e. run if a file they're importing changes), it doesn't work.

Concurrently fixes this because it handles running the projects and they handle (separately) which tests should run.
