### PR TITLE
chore: warn if webpack fails to create the fixtures

### DIFF
--- a/packages/shared/tooling/webpack-compile.ts
+++ b/packages/shared/tooling/webpack-compile.ts
@@ -1,6 +1,17 @@
 import { spawnSync } from "child_process";
+import { rmSync, existsSync } from "fs";
+import path from "path";
+
+const __dirname = new URL(".", import.meta.url).pathname;
+
+const FIXTURES_DIR = path.join(__dirname, "../../../__fixtures__/dist");
 
 export const compileForTests = () => {
+  // It's necessary to manually remove the previous build artifacts so we can
+  // check that the build is successful. This should not be necessary, but
+  // webpack can fail silently.
+  rmSync(FIXTURES_DIR, { recursive: true, force: true });
+
   // It's necessary spawnSync the webpack process to ensure that the build is
   // complete before the tests start
   const result = spawnSync(
@@ -11,6 +22,14 @@ export const compileForTests = () => {
       encoding: "utf8",
     },
   );
+
+  if (!existsSync(FIXTURES_DIR)) {
+    console.log(result.stdout);
+    console.error(result.stderr);
+    console.error(
+      `Webpack build failed. The dist folder, ${FIXTURES_DIR}, was not created.`,
+    );
+  }
 
   // Only log if there is an error
   if (result.status) {


### PR DESCRIPTION
It's quite possible for webpack's cache to get messed up and then it can silently fail to build.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
