### PR TITLE
feat: support top-level await in tests

### DIFF
--- a/packages/javascript-evaluator/src/javascript-test-evaluator.ts
+++ b/packages/javascript-evaluator/src/javascript-test-evaluator.ts
@@ -13,6 +13,7 @@ import type {
 import type { ReadyEvent } from "../../shared/src/interfaces/test-runner";
 import { postCloneableMessage } from "../../shared/src/messages";
 import { format } from "../../shared/src/format";
+import { createAsyncIife } from "../../shared/src/async-iife";
 import { ProxyConsole } from "../../shared/src/proxy-console";
 
 const READY_MESSAGE: ReadyEvent["data"] = { type: "ready" };
@@ -27,11 +28,6 @@ globalThis.__helpers = curriculumHelpers;
 
 Object.freeze(globalThis.__helpers);
 Object.freeze(globalThis.assert);
-
-// The newline is important, because otherwise comments will cause the trailing
-// `}` to be ignored, breaking the tests.
-const wrapCode = (code: string) => `(async () => {${code};
-})();`;
 
 // TODO: currently this is almost identical to DOMTestEvaluator, can we make
 // it more DRY? Don't attempt until they're both more fleshed out.
@@ -50,7 +46,7 @@ export class JavascriptTestEvaluator implements TestEvaluator {
 
     this.#runTest = async (rawTest) => {
       this.#proxyConsole.on();
-      const test = wrapCode(rawTest);
+      const test = createAsyncIife(rawTest);
       // This can be reassigned by the eval inside the try block, so it should be declared as a let
       // eslint-disable-next-line prefer-const
       let __userCodeWasExecuted = false;

--- a/packages/shared/src/async-iife.ts
+++ b/packages/shared/src/async-iife.ts
@@ -1,0 +1,4 @@
+// The newline is important, because otherwise comments will cause the trailing
+// `}` to be ignored, breaking the tests.
+export const createAsyncIife = (code: string) => `(async () => {${code};
+})();`;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This makes all three explicitly support top-level await in tests. Since DOM lessons supported `async () => {}` style lessons, that has to continue, but it will be deprecated in the next major release.

<!-- Feel free to add any additional description of changes below this line -->
