### PR TITLE
feat: add timeouts for creating test runners

### DIFF
--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -24,7 +24,6 @@ interface EvaluatorConfig {
 }
 
 interface RunnerConfig {
-  // This only applies to DOM tests for now.
   timeout?: number;
 }
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

In principle it's possible for the `init` call to simply never resolve. This adds an explicit timeout and throws if it is exceeded giving the caller more control over how long this can take.

Mostly this serves to help debugging, because the timeout triggers if the frame fails to load. This means we can infer, depending on if we see that error or not, what failed.

<!-- Feel free to add any additional description of changes below this line -->
