### PR TITLE
feat: drop support for object form python tests

### DIFF
--- a/packages/python-evaluator/src/python-test-evaluator.ts
+++ b/packages/python-evaluator/src/python-test-evaluator.ts
@@ -21,11 +21,6 @@ import { format } from "../../shared/src/format";
 import { ProxyConsole } from "../../shared/src/proxy-console";
 import { createAsyncIife } from "../../shared/src/async-iife";
 
-type EvaluatedTeststring = {
-  input?: string[];
-  test: () => Promise<unknown>;
-};
-
 const READY_MESSAGE: ReadyEvent["data"] = { type: "ready" };
 
 function isProxy(raw: unknown): raw is PyProxy {
@@ -90,102 +85,23 @@ class PythonTestEvaluator implements TestEvaluator {
 
       try {
         eval(opts.hooks?.beforeEach ?? "");
-        // Eval test string to get the dummy input and actual test
-        const evaluatedTestString = await new Promise<unknown>(
-          (resolve, reject) => {
-            try {
-              const test: unknown = eval(testString);
-              resolve(test);
-            } catch (err) {
-              const isUsingTopLevelAwait =
-                err instanceof SyntaxError &&
-                err.message.includes(
-                  "await is only valid in async functions and the top level bodies of modules",
-                );
 
-              if (isUsingTopLevelAwait) {
-                const iifeTest = createAsyncIife(testString);
+        const iifeTest = createAsyncIife(testString);
 
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-                eval(iifeTest).then(resolve).catch(reject);
-              } else {
-                // The assumption is that if we're in this block, then the test
-                // is EITHER a standard JS test (in which case it should reject)
-                // OR a Python test that uses the `input()` function (in which case
-                // we need to fake the input function).
-
-                // While supporting both `{ test: () => { // test code } }` and
-                // `// test code /` we have to fake input before running the
-                // test. Otherwise any user code that uses `input()` will throw
-                // an error.
-                runPython(`
+        // If input isn't reassigned, it will throw when called during testing.
+        runPython(`
 def __fake_input(arg=None):
   return ""
 
 input = __fake_input
-  `);
+`);
 
-                // Evaluates the learner's code so that any variables they
-                // define are available to the test.
-                try {
-                  // It looks the source might be evaluated twice, but they're
-                  // on separate branches.
-                  runPython(opts.source ?? "");
-                } catch (sourceErr) {
-                  // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
-                  reject(sourceErr);
-                  return;
-                }
+        // Evaluates the learner's code so that any variables they
+        // define are available to the test.
 
-                try {
-                  eval(testString);
-                } catch (testErr) {
-                  // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
-                  reject(testErr);
-                }
-
-                resolve(undefined);
-              }
-            }
-          },
-        );
-
-        // If the test string does not evaluate to an object, then we assume that
-        // it's a standard JS test and any assertions have already passed.
-        if (typeof evaluatedTestString !== "object") {
-          // Execute afterEach hook if it exists
-          if (opts.hooks?.afterEach) eval(opts.hooks.afterEach);
-
-          return { pass: true, ...this.#proxyConsole.flush() };
-        }
-
-        if (!evaluatedTestString || !("test" in evaluatedTestString)) {
-          throw Error(
-            "Test string did not evaluate to an object with the 'test' property",
-          );
-        }
-
-        const { input, test } = evaluatedTestString as EvaluatedTeststring;
-
-        runPython(`
-		def __inputGen(xs):
-			def gen():
-				for x in xs:
-					yield x
-			iter = gen()
-			def input(arg=None):
-				return next(iter)
-
-			return input
-
-		input = __inputGen(${JSON.stringify(input ?? [])})
-		`);
-
-        // Evaluates the learner's code so that any variables they define are
-        // available to the test.
         runPython(opts.source ?? "");
 
-        await test();
+        await eval(iifeTest);
 
         if (opts.hooks?.afterEach) eval(opts.hooks.afterEach);
 

--- a/packages/tests/integration-tests/index.test.ts
+++ b/packages/tests/integration-tests/index.test.ts
@@ -1184,11 +1184,7 @@ assert(mocked.find('.greeting').length === 1);
           type: "python",
           source,
         });
-        return runner?.runTest(
-          `({
-test: () => assert.equal(runPython('get_five()'), 5),
-						})`,
-        );
+        return runner?.runTest(`assert.equal(runPython('get_five()'), 5)`);
       }, source);
 
       expect(result).toEqual({ pass: true });
@@ -1207,11 +1203,7 @@ test: () => assert.equal(runPython('get_five()'), 5),
       const result = await page.evaluate(async () => {
         const runner = window.FCCTestRunner.getRunner("python");
         await runner?.init({}, 1000);
-        return runner?.runTest(
-          `({
-test: () => assert.equal(runPython('get_five()'), 5),
-						})`,
-        );
+        return runner?.runTest(`assert.equal(runPython('get_five()'), 5)`);
       });
 
       expect(result).toMatchObject({
@@ -1230,9 +1222,7 @@ test: () => assert.equal(runPython('get_five()'), 5),
           type: "python",
         });
         return runner?.runTest(
-          `({
-test: () => assert.equal(runPython('__name__'), '__main__'),
-						})`,
+          `assert.equal(runPython('__name__'), '__main__')`,
         );
       });
 
@@ -1263,45 +1253,6 @@ test: () => assert.equal(runPython('__name__'), '__main__'),
       });
     });
 
-    it("should reject testStrings that evaluate to an invalid object", async () => {
-      const result = await page.evaluate(async () => {
-        const runner = await window.FCCTestRunner.createTestRunner({
-          type: "python",
-        });
-        return runner?.runTest(`({ invalid: 'test' })`);
-      });
-
-      expect(result).toEqual({
-        err: {
-          message:
-            "Test string did not evaluate to an object with the 'test' property",
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          stack: expect.stringContaining(
-            "Error: Test string did not evaluate to an object with the 'test' property",
-          ),
-        },
-      });
-    });
-
-    it("should be able to test with mock input", async () => {
-      const result = await page.evaluate(async () => {
-        const runner = await window.FCCTestRunner.createTestRunner({
-          type: "python",
-          source: `
-first = input()
-second = input()
-`,
-        });
-
-        return runner?.runTest(`({
-	input: ["argle", "bargle"],
-  test: () => assert.equal(runPython('first + second'), "arglebargle")
-})`);
-      });
-
-      expect(result).toEqual({ pass: true });
-    });
-
     it("should make user code available to the python code as the _code variable", async () => {
       const result = await page.evaluate(async () => {
         const runner = await window.FCCTestRunner.createTestRunner({
@@ -1311,9 +1262,9 @@ second = input()
           },
         });
 
-        return runner?.runTest(`({
-  test: () => assert.equal(runPython('_code'), "test = 'value'")
-})`);
+        return runner?.runTest(
+          `assert.equal(runPython('_code'), "test = 'value'")`,
+        );
       });
 
       expect(result).toEqual({ pass: true });
@@ -1324,9 +1275,9 @@ second = input()
         const runner = await window.FCCTestRunner.createTestRunner({
           type: "python",
         });
-        return runner?.runTest(`({
-  test: () => assert.equal(runPython('_Node("x = 1").get_variable("x")'), 1)
-})`);
+        return runner?.runTest(
+          `assert.equal(runPython('_Node("x = 1").get_variable("x")'), 1)`,
+        );
       });
 
       expect(result).toEqual({ pass: true });
@@ -1344,9 +1295,7 @@ second = input()
           },
         });
 
-        return runner?.runTest(`({
-  test: () => {}
-})`);
+        return runner?.runTest("");
       });
 
       expect(result).toEqual({ pass: true });
@@ -1372,9 +1321,7 @@ second = input()
         const runner = await window.FCCTestRunner.createTestRunner({
           type: "python",
         });
-        return runner?.runTest(`({
-	test: () => assert.equal(runPython('1 + "1"'), 2)
-})`);
+        return runner?.runTest(`assert.equal(runPython('1 + "1"'), 2)`);
       });
       expect(result).toEqual({
         err: {
@@ -1400,9 +1347,7 @@ pattern = re.compile('l+')
           type: "python",
           source,
         });
-        return runner?.runTest(`({
-	test: () => assert.equal(runPython('str(pattern)'), "l+")
-})`);
+        return runner?.runTest(`assert.equal(runPython('str(pattern)'), "l+")`);
       }, source);
       expect(result).toEqual({
         err: {
@@ -1429,9 +1374,9 @@ pattern = re.compile('l+')`;
         });
         // Since the comparison includes a PyProxy object, that will be
         // posted back to the caller and cause a DataCloneError
-        return runner?.runTest(`
-  ({ test: () => assert.equal(__userGlobals.get("pattern"), "l+") })
-`);
+        return runner?.runTest(
+          `assert.equal(__userGlobals.get("pattern"), "l+")`,
+        );
       }, source);
 
       expect(result).toEqual({
@@ -1476,7 +1421,7 @@ pattern = re.compile('l+')`;
       });
     });
 
-    it("should use a fake input function in simple tests", async () => {
+    it("should not throw when input is called during a test", async () => {
       const result = await page.evaluate(async () => {
         const runner = await window.FCCTestRunner.createTestRunner({
           type: "python",

--- a/packages/tests/integration-tests/timeout.test.ts
+++ b/packages/tests/integration-tests/timeout.test.ts
@@ -86,9 +86,7 @@ def run():
           source,
         });
         const result = await runner?.runTest(
-          `({
-						test: () => assert.equal(runPython('loop()'), 1)
-				})`,
+          `assert.equal(runPython('loop()'), 1)`,
           10,
         );
         return result;
@@ -102,11 +100,7 @@ def run():
           },
           source,
         });
-        return runner?.runTest(
-          `({
-						test: () => assert.equal(runPython('run()'), 1)
-				})`,
-        );
+        return runner?.runTest(`assert.equal(runPython('run()'), 1)`);
       }, source);
 
       expect(timeoutResult).toEqual({
@@ -132,12 +126,7 @@ while True:
           },
           source,
         });
-        return runner?.runTest(
-          `({
-						test: () => assert.equal(runPython('1'), 1)
-				})`,
-          10,
-        );
+        return runner?.runTest(`assert.equal(runPython('1'), 1)`, 10);
       }, source);
 
       expect(result).toEqual({


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Now object form tests will effectively be ignored since the object will be evaluated, but not the test function.


<!-- Feel free to add any additional description of changes below this line -->
