### PR TITLE
fix: input mock order

### DIFF
--- a/packages/python-evaluator/src/python-test-evaluator.ts
+++ b/packages/python-evaluator/src/python-test-evaluator.ts
@@ -84,10 +84,6 @@ class PythonTestEvaluator implements TestEvaluator {
       /* eslint-enable @typescript-eslint/no-unused-vars */
 
       try {
-        eval(opts.hooks?.beforeEach ?? "");
-
-        const iifeTest = createAsyncIife(testString);
-
         // If input isn't reassigned, it will throw when called during testing.
         runPython(`
 def __fake_input(arg=None):
@@ -95,6 +91,9 @@ def __fake_input(arg=None):
 
 input = __fake_input
 `);
+        eval(opts.hooks?.beforeEach ?? "");
+
+        const iifeTest = createAsyncIife(testString);
 
         // Evaluates the learner's code so that any variables they
         // define are available to the test.

--- a/packages/tests/integration-tests/index.test.ts
+++ b/packages/tests/integration-tests/index.test.ts
@@ -1431,5 +1431,45 @@ pattern = re.compile('l+')`;
 
       expect(result).toEqual({ pass: true });
     });
+
+    it("should supporting input mocking", async () => {
+      const beforeEach = `runPython('input = lambda: "test input"')`;
+      const result = await page.evaluate(async (beforeEach) => {
+        const runner = await window.FCCTestRunner.createTestRunner({
+          type: "python",
+          hooks: {
+            beforeEach,
+          },
+        });
+        return runner?.runTest(
+          `assert.equal(runPython('input()'), "test input")`,
+        );
+      }, beforeEach);
+
+      expect(result).toEqual({ pass: true });
+    });
+
+    it("should support input mocking in user code", async () => {
+      const source = `name = input()`;
+      const beforeEach = `runPython('input = lambda: "mocked input"')`;
+      const result = await page.evaluate(
+        async (source, beforeEach) => {
+          const runner = await window.FCCTestRunner.createTestRunner({
+            type: "python",
+            source,
+            hooks: {
+              beforeEach,
+            },
+          });
+          return runner?.runTest(
+            `assert.equal(runPython('name'), "mocked input")`,
+          );
+        },
+        source,
+        beforeEach,
+      );
+
+      expect(result).toEqual({ pass: true });
+    });
   });
 });


### PR DESCRIPTION
It's important to mock input so that unexpected input statements don't immediately break tests
but it needs to be possible to override that with beforeEach

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
