### PR TITLE
fix: handle invalid python syntax

### DIFF
--- a/packages/python-evaluator/src/python-test-evaluator.ts
+++ b/packages/python-evaluator/src/python-test-evaluator.ts
@@ -113,7 +113,13 @@ input = __fake_input
         // Evaluates the learner's code so that any variables they
         // define are available to the test.
 
-        runPython(opts.source ?? "");
+        try {
+          runPython(opts.source ?? "");
+        } catch {
+          // Tests should not automatically fail if there's an error in the
+          // source. Various tests are only interested in using regexes on the
+          // code.
+        }
 
         await eval(iifeTest);
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Tests should not automatically fail if there's an error in the source. Various tests are only interested in using regexes on the code.

<!-- Feel free to add any additional description of changes below this line -->
