### PR TITLE
feat: reinstate support for object syntax

### DIFF
--- a/packages/python-evaluator/src/python-test-evaluator.ts
+++ b/packages/python-evaluator/src/python-test-evaluator.ts
@@ -113,13 +113,7 @@ input = __fake_input
         // Evaluates the learner's code so that any variables they
         // define are available to the test.
 
-        try {
-          runPython(opts.source ?? "");
-        } catch {
-          // Tests should not automatically fail if there's an error in the
-          // source. Various tests are only interested in using regexes on the
-          // code.
-        }
+        runPython(opts.source ?? "");
 
         await eval(iifeTest);
 

--- a/packages/python-evaluator/src/python-test-evaluator.ts
+++ b/packages/python-evaluator/src/python-test-evaluator.ts
@@ -22,6 +22,11 @@ import { format } from "../../shared/src/format";
 import { ProxyConsole } from "../../shared/src/proxy-console";
 import { createAsyncIife } from "../../shared/src/async-iife";
 
+type EvaluatedTeststring = {
+  input?: string[];
+  test: () => Promise<unknown>;
+};
+
 const READY_MESSAGE: ReadyEvent["data"] = { type: "ready" };
 
 function isProxy(raw: unknown): raw is PyProxy {
@@ -99,23 +104,104 @@ class PythonTestEvaluator implements TestEvaluator {
       /* eslint-enable @typescript-eslint/no-unused-vars */
 
       try {
-        // If input isn't reassigned, it will throw when called during testing.
-        runPython(`
+        eval(opts.hooks?.beforeEach ?? "");
+        // Eval test string to get the dummy input and actual test
+        const evaluatedTestString = await new Promise<unknown>(
+          (resolve, reject) => {
+            try {
+              const test: unknown = eval(testString);
+              resolve(test);
+            } catch (err) {
+              const isUsingTopLevelAwait =
+                err instanceof SyntaxError &&
+                err.message.includes(
+                  "await is only valid in async functions and the top level bodies of modules",
+                );
+
+              if (isUsingTopLevelAwait) {
+                const iifeTest = createAsyncIife(testString);
+
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+                eval(iifeTest).then(resolve).catch(reject);
+              } else {
+                // The assumption is that if we're in this block, then the test
+                // is EITHER a standard JS test (in which case it should reject)
+                // OR a Python test that uses the `input()` function (in which case
+                // we need to fake the input function).
+
+                // While supporting both `{ test: () => { // test code } }` and
+                // `// test code /` we have to fake input before running the
+                // test. Otherwise any user code that uses `input()` will throw
+                // an error.
+                runPython(`
 def __fake_input(arg=None):
   return ""
 
 input = __fake_input
 `);
-        eval(opts.hooks?.beforeEach ?? "");
+                eval(opts.hooks?.beforeEach ?? "");
 
-        const iifeTest = createAsyncIife(testString);
+                // Evaluates the learner's code so that any variables they
+                // define are available to the test.
+                try {
+                  // It looks the source might be evaluated twice, but they're
+                  // on separate branches.
+                  runPython(opts.source ?? "");
+                } catch (sourceErr) {
+                  // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
+                  reject(sourceErr);
+                  return;
+                }
 
-        // Evaluates the learner's code so that any variables they
-        // define are available to the test.
+                try {
+                  eval(testString);
+                } catch (testErr) {
+                  // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
+                  reject(testErr);
+                }
 
+                resolve(undefined);
+              }
+            }
+          },
+        );
+
+        // If the test string does not evaluate to an object, then we assume that
+        // it's a standard JS test and any assertions have already passed.
+        if (typeof evaluatedTestString !== "object") {
+          // Execute afterEach hook if it exists
+          if (opts.hooks?.afterEach) eval(opts.hooks.afterEach);
+
+          return { pass: true, ...this.#proxyConsole.flush() };
+        }
+
+        if (!evaluatedTestString || !("test" in evaluatedTestString)) {
+          throw Error(
+            "Test string did not evaluate to an object with the 'test' property",
+          );
+        }
+
+        const { input, test } = evaluatedTestString as EvaluatedTeststring;
+
+        runPython(`
+		def __inputGen(xs):
+			def gen():
+				for x in xs:
+					yield x
+			iter = gen()
+			def input(arg=None):
+				return next(iter)
+
+			return input
+
+		input = __inputGen(${JSON.stringify(input ?? [])})
+		`);
+
+        // Evaluates the learner's code so that any variables they define are
+        // available to the test.
         runPython(opts.source ?? "");
 
-        await eval(iifeTest);
+        await test();
 
         return { pass: true, ...this.#proxyConsole.flush() };
       } catch (err) {

--- a/packages/tests/integration-tests/index.test.ts
+++ b/packages/tests/integration-tests/index.test.ts
@@ -1492,50 +1492,5 @@ pattern = re.compile('l+')`;
 
       expect(result).toEqual({ pass: true });
     });
-
-    it("should not automatically fail tests if the source raises an error", async () => {
-      const source = `
-def func():
-pass
-      `;
-      const result = await page.evaluate(async (source) => {
-        const runner = await window.FCCTestRunner.createTestRunner({
-          type: "python",
-          source,
-        });
-        return runner?.runTest(`assert.equal(1, 2)`);
-      }, source);
-
-      expect(result).toMatchObject({
-        err: {
-          expected: 2,
-          actual: 1,
-        },
-      });
-    });
-
-    it("should be possible to re-run user code inside a test to detect errors", async () => {
-      const source = `
-def func():
-pass
-      `;
-
-      const result = await page.evaluate(async (source) => {
-        const runner = await window.FCCTestRunner.createTestRunner({
-          type: "python",
-          source,
-          code: {
-            contents: source,
-          },
-        });
-        return runner?.runTest(`runPython(code)`);
-      }, source);
-
-      expect(result).toMatchObject({
-        err: {
-          type: "IndentationError",
-        },
-      });
-    });
   });
 });

--- a/packages/tests/integration-tests/timeout.test.ts
+++ b/packages/tests/integration-tests/timeout.test.ts
@@ -86,7 +86,9 @@ def run():
           source,
         });
         const result = await runner?.runTest(
-          `assert.equal(runPython('loop()'), 1)`,
+          `({
+						test: () => assert.equal(runPython('loop()'), 1)
+				})`,
           10,
         );
         return result;
@@ -100,7 +102,11 @@ def run():
           },
           source,
         });
-        return runner?.runTest(`assert.equal(runPython('run()'), 1)`);
+        return runner?.runTest(
+          `({
+						test: () => assert.equal(runPython('run()'), 1)
+				})`,
+        );
       }, source);
 
       expect(timeoutResult).toEqual({
@@ -126,7 +132,12 @@ while True:
           },
           source,
         });
-        return runner?.runTest(`assert.equal(runPython('1'), 1)`, 10);
+        return runner?.runTest(
+          `({
+						test: () => assert.equal(runPython('1'), 1)
+				})`,
+          10,
+        );
       }, source);
 
       expect(result).toEqual({


### PR DESCRIPTION
- **Revert "fix: handle invalid python syntax (#408)"**
- **Revert "feat: drop support for object form python tests (#401)"**
- **feat: stop supporting simple tests + input arrays**

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

While the object syntax is a little awkward, it makes it easier to test python code that does not terminate. Simply because if the test isn't in the object form, the python code is not evaluated.

The simpler tests, by design, always ran the python code and so would timeout if evaluation never terminated.

<!-- Feel free to add any additional description of changes below this line -->
