### PR TITLE
fix: prevent form navigation

### DIFF
--- a/packages/dom-evaluator/src/dom-test-evaluator.ts
+++ b/packages/dom-evaluator/src/dom-test-evaluator.ts
@@ -49,6 +49,12 @@ const removeTestScripts = () => {
   hooksScript?.remove();
 };
 
+// Prevent form submissions from navigating the page. If we don't do this, the
+// iframe's browsing context could be replaced destroying the test runner.
+document.addEventListener("submit", (e) => {
+  e.preventDefault();
+});
+
 export class DOMTestEvaluator implements TestEvaluator {
   #runTest?: TestEvaluator["runTest"];
   #proxyConsole: ProxyConsole;

--- a/packages/tests/integration-tests/index.test.ts
+++ b/packages/tests/integration-tests/index.test.ts
@@ -1098,6 +1098,37 @@ assert(mocked.find('.greeting').length === 1);
         });
       },
     );
+
+    it("should prevent forms from triggering navigation", async () => {
+      const source = `<!DOCTYPE html>
+        <form>
+        <button id="check-btn">Check</button>
+        </form>
+  `;
+
+      const result = await page.evaluate(async (source) => {
+        const runner = await window.FCCTestRunner.createTestRunner({
+          source,
+          type: "dom",
+        });
+
+        await runner.runTest(`
+const checkBtn = document.getElementById('check-btn');
+checkBtn.click();`);
+
+        // Small delay to allow the page to navigate (if it does)
+        await new Promise((resolve) => {
+          setTimeout(resolve, 100);
+        });
+
+        return runner.runTest(`
+const checkBtn = document.getElementById('check-btn');
+checkBtn.click();
+       `);
+      }, source);
+
+      expect(result).toEqual({ pass: true });
+    });
   });
 
   describe("Javascript evaluator", () => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Form navigation seems to destroy the frame's content, including the test runner, and cause all subsequent tests to fail

<!-- Feel free to add any additional description of changes below this line -->
