### PR TITLE
fix: call spied on functions with 'this'

### DIFF
--- a/packages/tests/curriculum-helper.test.tsx
+++ b/packages/tests/curriculum-helper.test.tsx
@@ -132,6 +132,32 @@ describe("spyOn", () => {
     obj.method("arg");
     expect(spy.calls).toEqual([]);
   });
+
+  it("should call the original function, providing 'this'", () => {
+    const obj = {
+      value: "obj",
+      method(arg = "") {
+        return this.value + arg;
+      },
+    };
+
+    const spy = helper.spyOn(obj, "method");
+    const result = obj.method("arg");
+    expect(result).toBe("objarg");
+    expect(spy.calls).toEqual([["arg"]]);
+  });
+
+  it("should throw if the spied on property is not a function", () => {
+    const obj = {
+      notAFunction: "foo",
+    };
+
+    vitest.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(() => helper.spyOn(obj, "notAFunction")).toThrow(
+      "spyOn can only be called on function properties",
+    );
+  });
 });
 
 describe("spyOnCallbacks", () => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Previously if a method that used `this` was spied on, calls to the spied on method would fail. Now, `this` is explicitly provided, so calling `xs.flat()` after `spyOn(Array.prototype, 'flat')` will not throw.

Also, to prevent confusing errors, `spyOn` will throw if you try to spy on something that's not a function.

<!-- Feel free to add any additional description of changes below this line -->
