### PR TITLE
feat: make __helpers available in all before hooks

### DIFF
--- a/packages/javascript-evaluator/src/javascript-test-evaluator.ts
+++ b/packages/javascript-evaluator/src/javascript-test-evaluator.ts
@@ -69,7 +69,7 @@ export class JavascriptTestEvaluator implements TestEvaluator {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const editableContents = opts.code?.editableContents ?? "";
         try {
-          await eval(`${opts.hooks?.beforeEach ?? ""}
+          await eval(`${opts.hooks?.beforeEach ?? ""};
 ${opts.source};
 __userCodeWasExecuted = true;
 ${test};`);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

They're now available in both before-each and before-all. Also, they're available in all three environments: dom, javascript and python.

<!-- Feel free to add any additional description of changes below this line -->
