### PR TITLE
fix: has_returns and inherits_from helpers

### DIFF
--- a/packages/helpers/python/py_helpers.py
+++ b/packages/helpers/python/py_helpers.py
@@ -383,7 +383,10 @@ class Node:
             return False
         if not self.tree.bases:
             return False
-        id_list = [node.id for node in self.tree.bases]
+        id_list = [
+            node.id if isinstance(node, ast.Name) else f"{node.value.id}.{node.attr}"
+            for node in self.tree.bases
+        ]
         return all(arg in id_list for arg in args)
 
     # Find an array of if statements

--- a/packages/helpers/python/py_helpers.test.py
+++ b/packages/helpers/python/py_helpers.test.py
@@ -525,12 +525,16 @@ class A:
 
 class B(A, C):
    pass
+   
+class C(abc.ABC):
+   pass
 """
         node = Node(code_str)
 
         self.assertFalse(node.find_class("A").inherits_from("B"))
         self.assertTrue(node.find_class("B").inherits_from("C", "A"))
         self.assertTrue(node.find_class("B").inherits_from("A"))
+        self.assertTrue(node.find_class("C").inherits_from("abc.ABC"))
 
     def test_find_method_args(self):
         code_str = """


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
`has_returns("None")` was failing because it compared `None` with the string `"None"`.
`inherits_from("abc.ABC")` was failing because it could not handle the argument.
This PR fixes both issues.
