### PR TITLE
feat: preserve html entities in proxy console

### DIFF
--- a/packages/shared/src/proxy-console.ts
+++ b/packages/shared/src/proxy-console.ts
@@ -9,6 +9,18 @@ export const LEVELS = [
 
 type Level = (typeof LEVELS)[number];
 
+const PRESERVE_HTML_ENTITIES = ["amp", "lt", "gt", "quot", "apos"];
+
+// Double-encode PRESERVE_HTML_ENTITIES so they survive decoding by sanitizeHtml
+// in freeCodeCamp/client/src/templates/Challenges/components/output.tsx
+function preserveHtmlEntities(str: string): string {
+  const entityPattern = new RegExp(
+    `&(${PRESERVE_HTML_ENTITIES.join("|")})(;?)`,
+    "g",
+  );
+  return str.replace(entityPattern, "&amp;$1$2");
+}
+
 export class ProxyConsole {
   #originalConsole: Console;
   #proxyConsole: Console;
@@ -32,7 +44,9 @@ export class ProxyConsole {
     for (const level of LEVELS) {
       this.#proxyConsole[level] = (...args: unknown[]) => {
         this.#originalConsole[level](...args);
-        const msg = args.map((arg) => this.#format(arg)).join(" ");
+        const msg = preserveHtmlEntities(
+          args.map((arg) => this.#format(arg)).join(" "),
+        );
         this.#calls.push({ level, msg });
       };
     }

--- a/packages/tests/proxy-console.test.ts
+++ b/packages/tests/proxy-console.test.ts
@@ -99,4 +99,28 @@ describe("proxy-console", () => {
       expect(results).toEqual({});
     });
   });
+
+  describe("preserveHtmlEntities", () => {
+    it("should double-encode HTML entities so they survive sanitizeHtml decoding", () => {
+      vi.spyOn(window.console, "log").mockImplementation(vi.fn());
+      const proxy = new ProxyConsole(window.console, simpleFormat);
+      proxy.on();
+
+      window.console.log("A &amp; B");
+      const results = proxy.flush();
+
+      expect(results.logs).toEqual([{ level: "log", msg: "A &amp;amp; B" }]);
+    });
+
+    it("should not encode & that is not part of an HTML entity", () => {
+      vi.spyOn(window.console, "log").mockImplementation(vi.fn());
+      const proxy = new ProxyConsole(window.console, simpleFormat);
+      proxy.on();
+
+      window.console.log("A & B");
+      const results = proxy.flush();
+
+      expect(results.logs).toEqual([{ level: "log", msg: "A & B" }]);
+    });
+  });
 });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes [#63788](https://github.com/freeCodeCamp/freeCodeCamp/issues/63788)

<!-- Feel free to add any additional description of changes below this line -->

Double-encode HTML entities in `proxy-console` before the string reaches `sanitizeHtml`. For example `&amp;` becomes `&amp;amp;` and `sanitizeHtml` then decodes it back to `&amp;` which the browser renders as the literal text `&amp;`.

Babel/system errors go through `window.onerror` and bypass `proxy-console` entirely, so they are unaffected by this change.

To verify the fix locally, the built output was manually patched in the freeCodeCamp dev environment using a Python script that replaced the relevant line in the bundled javascript-test-evaluator.js files:

```
client/static/js/test-runner/8.0.0/javascript-test-evaluator.js
client/public/js/test-runner/8.0.0/javascript-test-evaluator.js
tools/client-plugins/browser-scripts/dist/js/test-runner/8.0.0/javascript-test-evaluator.js
```

The patch replaced:

```js
const n=t.map((e=>this.#o(e))).join(" ");this.#r.push({level:e,msg:n})
```

With:

```js
const n=t.map((e=>this.#o(e))).join(" ").replace(/&(amp|lt|gt|quot|apos)(;?)/g,"&amp;$1$2");this.#r.push({level:e,msg:n})
```

<details>
  <summary>Images</summary> 
  <p align="center">
    <img width="600" height="400" alt="brave_screenshot_silver-palm-tree-pjvvwj4r9vxvh7w9p-8000 app github dev (1)" src="https://github.com/user-attachments/assets/5d7b6d19-e493-4a90-8e4d-cd0626bb4b56" />
    <img width="600" height="400" alt="brave_screenshot_silver-palm-tree-pjvvwj4r9vxvh7w9p-8000 app github dev" src="https://github.com/user-attachments/assets/f329a2b4-04d8-446b-a932-551a5e5d89f3" />
    <img width="600" height="400" alt="brave_screenshot_expert-system-jj667jv5gr4gfjqpx-8000 app github dev (2)" src="https://github.com/user-attachments/assets/c4b4a1d7-c412-4821-819d-895a7da7444b" />
  </p>
</details>