### PR TITLE
fix: preserve falsy assertion expected/actual values

### DIFF
--- a/packages/dom-evaluator/src/dom-test-evaluator.ts
+++ b/packages/dom-evaluator/src/dom-test-evaluator.ts
@@ -67,8 +67,10 @@ export class DOMTestEvaluator implements TestEvaluator {
   #proxyConsole: ProxyConsole;
 
   #createErrorResponse(error: TestError) {
-    const hasExpected = Object.hasOwn(error, "expected");
-    const hasActual = Object.hasOwn(error, "actual");
+    const hasExpected =
+      Object.hasOwn(error, "expected") && error.expected !== undefined;
+    const hasActual =
+      Object.hasOwn(error, "actual") && error.actual !== undefined;
 
     return {
       err: {

--- a/packages/dom-evaluator/src/dom-test-evaluator.ts
+++ b/packages/dom-evaluator/src/dom-test-evaluator.ts
@@ -67,12 +67,15 @@ export class DOMTestEvaluator implements TestEvaluator {
   #proxyConsole: ProxyConsole;
 
   #createErrorResponse(error: TestError) {
+    const hasExpected = Object.hasOwn(error, "expected");
+    const hasActual = Object.hasOwn(error, "actual");
+
     return {
       err: {
         message: error.message,
         stack: error.stack,
-        ...(!!error.expected && { expected: error.expected }),
-        ...(!!error.actual && { actual: error.actual }),
+        ...(hasExpected && { expected: error.expected }),
+        ...(hasActual && { actual: error.actual }),
       },
     };
   }

--- a/packages/dom-evaluator/src/dom-test-evaluator.ts
+++ b/packages/dom-evaluator/src/dom-test-evaluator.ts
@@ -17,6 +17,7 @@ import type {
 import type { ReadyEvent } from "../../shared/src/interfaces/test-runner";
 
 import { postCloneableMessage } from "../../shared/src/messages";
+import { hasDefinedProperty } from "../../shared/src/has-defined-property";
 import {
   TEST_EVALUATOR_SCRIPT_ID,
   TEST_EVALUATOR_HOOKS_ID,
@@ -67,10 +68,8 @@ export class DOMTestEvaluator implements TestEvaluator {
   #proxyConsole: ProxyConsole;
 
   #createErrorResponse(error: TestError) {
-    const hasExpected =
-      Object.hasOwn(error, "expected") && error.expected !== undefined;
-    const hasActual =
-      Object.hasOwn(error, "actual") && error.actual !== undefined;
+    const hasExpected = hasDefinedProperty(error, "expected");
+    const hasActual = hasDefinedProperty(error, "actual");
 
     return {
       err: {

--- a/packages/javascript-evaluator/src/javascript-test-evaluator.ts
+++ b/packages/javascript-evaluator/src/javascript-test-evaluator.ts
@@ -39,12 +39,15 @@ export class JavascriptTestEvaluator implements TestEvaluator {
   #proxyConsole: ProxyConsole;
 
   #createErrorResponse(error: TestError) {
+    const hasExpected = Object.hasOwn(error, "expected");
+    const hasActual = Object.hasOwn(error, "actual");
+
     return {
       err: {
         message: error.message,
         stack: error.stack,
-        ...(!!error.expected && { expected: error.expected }),
-        ...(!!error.actual && { actual: error.actual }),
+        ...(hasExpected && { expected: error.expected }),
+        ...(hasActual && { actual: error.actual }),
       },
     };
   }

--- a/packages/javascript-evaluator/src/javascript-test-evaluator.ts
+++ b/packages/javascript-evaluator/src/javascript-test-evaluator.ts
@@ -39,8 +39,10 @@ export class JavascriptTestEvaluator implements TestEvaluator {
   #proxyConsole: ProxyConsole;
 
   #createErrorResponse(error: TestError) {
-    const hasExpected = Object.hasOwn(error, "expected");
-    const hasActual = Object.hasOwn(error, "actual");
+    const hasExpected =
+      Object.hasOwn(error, "expected") && error.expected !== undefined;
+    const hasActual =
+      Object.hasOwn(error, "actual") && error.actual !== undefined;
 
     return {
       err: {

--- a/packages/javascript-evaluator/src/javascript-test-evaluator.ts
+++ b/packages/javascript-evaluator/src/javascript-test-evaluator.ts
@@ -14,6 +14,7 @@ import type {
 } from "../../shared/src/interfaces/test-evaluator";
 import type { ReadyEvent } from "../../shared/src/interfaces/test-runner";
 import { postCloneableMessage } from "../../shared/src/messages";
+import { hasDefinedProperty } from "../../shared/src/has-defined-property";
 import { format } from "../../shared/src/format";
 import { createAsyncIife } from "../../shared/src/async-iife";
 import { ProxyConsole } from "../../shared/src/proxy-console";
@@ -39,10 +40,8 @@ export class JavascriptTestEvaluator implements TestEvaluator {
   #proxyConsole: ProxyConsole;
 
   #createErrorResponse(error: TestError) {
-    const hasExpected =
-      Object.hasOwn(error, "expected") && error.expected !== undefined;
-    const hasActual =
-      Object.hasOwn(error, "actual") && error.actual !== undefined;
+    const hasExpected = hasDefinedProperty(error, "expected");
+    const hasActual = hasDefinedProperty(error, "actual");
 
     return {
       err: {

--- a/packages/python-evaluator/src/python-test-evaluator.ts
+++ b/packages/python-evaluator/src/python-test-evaluator.ts
@@ -49,14 +49,20 @@ class PythonTestEvaluator implements TestEvaluator {
   #proxyConsole: ProxyConsole;
 
   #createErrorResponse(error: TestError) {
-    const expected = serialize((error as { expected: unknown }).expected);
-    const actual = serialize((error as { actual: unknown }).actual);
+    const hasExpected = Object.hasOwn(error, "expected");
+    const hasActual = Object.hasOwn(error, "actual");
+    const expected = hasExpected
+      ? serialize((error as { expected: unknown }).expected)
+      : undefined;
+    const actual = hasActual
+      ? serialize((error as { actual: unknown }).actual)
+      : undefined;
     return {
       err: {
         message: error.message,
         stack: error.stack,
-        ...(!!expected && { expected }),
-        ...(!!actual && { actual }),
+        ...(hasExpected && { expected }),
+        ...(hasActual && { actual }),
         type: error.type,
       },
     };

--- a/packages/python-evaluator/src/python-test-evaluator.ts
+++ b/packages/python-evaluator/src/python-test-evaluator.ts
@@ -49,14 +49,13 @@ class PythonTestEvaluator implements TestEvaluator {
   #proxyConsole: ProxyConsole;
 
   #createErrorResponse(error: TestError) {
-    const hasExpected = Object.hasOwn(error, "expected");
-    const hasActual = Object.hasOwn(error, "actual");
-    const expected = hasExpected
-      ? serialize((error as { expected: unknown }).expected)
-      : undefined;
-    const actual = hasActual
-      ? serialize((error as { actual: unknown }).actual)
-      : undefined;
+    const rawExpected = (error as { expected?: unknown }).expected;
+    const rawActual = (error as { actual?: unknown }).actual;
+    const hasExpected =
+      Object.hasOwn(error, "expected") && rawExpected !== undefined;
+    const hasActual = Object.hasOwn(error, "actual") && rawActual !== undefined;
+    const expected = hasExpected ? serialize(rawExpected) : undefined;
+    const actual = hasActual ? serialize(rawActual) : undefined;
     return {
       err: {
         message: error.message,

--- a/packages/python-evaluator/src/python-test-evaluator.ts
+++ b/packages/python-evaluator/src/python-test-evaluator.ts
@@ -18,6 +18,7 @@ import {
 } from "../../shared/src/interfaces/test-evaluator";
 import { ReadyEvent } from "../../shared/src/interfaces/test-runner";
 import { postCloneableMessage } from "../../shared/src/messages";
+import { hasDefinedProperty } from "../../shared/src/has-defined-property";
 import { format } from "../../shared/src/format";
 import { ProxyConsole } from "../../shared/src/proxy-console";
 import { createAsyncIife } from "../../shared/src/async-iife";
@@ -49,13 +50,10 @@ class PythonTestEvaluator implements TestEvaluator {
   #proxyConsole: ProxyConsole;
 
   #createErrorResponse(error: TestError) {
-    const rawExpected = (error as { expected?: unknown }).expected;
-    const rawActual = (error as { actual?: unknown }).actual;
-    const hasExpected =
-      Object.hasOwn(error, "expected") && rawExpected !== undefined;
-    const hasActual = Object.hasOwn(error, "actual") && rawActual !== undefined;
-    const expected = hasExpected ? serialize(rawExpected) : undefined;
-    const actual = hasActual ? serialize(rawActual) : undefined;
+    const hasExpected = hasDefinedProperty(error, "expected");
+    const hasActual = hasDefinedProperty(error, "actual");
+    const expected = hasExpected ? serialize(error.expected) : undefined;
+    const actual = hasActual ? serialize(error.actual) : undefined;
     return {
       err: {
         message: error.message,

--- a/packages/shared/src/has-defined-property.ts
+++ b/packages/shared/src/has-defined-property.ts
@@ -1,0 +1,10 @@
+// Object.hasOwn on its own does not rule out a property that is explicitly
+// set to undefined, so callers that need to distinguish "missing" from
+// "present but undefined" from "present and defined" use this to check the
+// last case.
+export function hasDefinedProperty(obj: object, key: string): boolean {
+  return (
+    Object.hasOwn(obj, key) &&
+    (obj as Record<string, unknown>)[key] !== undefined
+  );
+}

--- a/packages/shared/src/messages.ts
+++ b/packages/shared/src/messages.ts
@@ -18,17 +18,19 @@ export const postCloneableMessage = (
     const result = msg.value;
     if ("err" in result) {
       const rawActual = result.err?.actual;
-      const actual = rawActual ? format(rawActual) : undefined;
+      const hasActual = Object.hasOwn(result.err, "actual");
+      const actual = hasActual ? format(rawActual) : undefined;
       const rawExpected = result.err?.expected;
-      const expected = rawExpected ? format(rawExpected) : undefined;
+      const hasExpected = Object.hasOwn(result.err, "expected");
+      const expected = hasExpected ? format(rawExpected) : undefined;
 
       const msgClone = {
         type: "result",
         value: {
           err: {
             ...result.err,
-            actual,
-            expected,
+            ...(hasActual && { actual }),
+            ...(hasExpected && { expected }),
           },
         },
       };

--- a/packages/shared/src/messages.ts
+++ b/packages/shared/src/messages.ts
@@ -18,10 +18,12 @@ export const postCloneableMessage = (
     const result = msg.value;
     if ("err" in result) {
       const rawActual = result.err?.actual;
-      const hasActual = Object.hasOwn(result.err, "actual");
+      const hasActual =
+        Object.hasOwn(result.err, "actual") && rawActual !== undefined;
       const actual = hasActual ? format(rawActual) : undefined;
       const rawExpected = result.err?.expected;
-      const hasExpected = Object.hasOwn(result.err, "expected");
+      const hasExpected =
+        Object.hasOwn(result.err, "expected") && rawExpected !== undefined;
       const expected = hasExpected ? format(rawExpected) : undefined;
 
       const msgClone = {

--- a/packages/shared/src/messages.ts
+++ b/packages/shared/src/messages.ts
@@ -1,5 +1,6 @@
 import type { Pass, Fail } from "./interfaces/test-evaluator";
 import { format } from "./format";
+import { hasDefinedProperty } from "./has-defined-property";
 
 type Message = {
   type: "result";
@@ -17,14 +18,10 @@ export const postCloneableMessage = (
     // of 'actual' or 'expected' is not transferable.
     const result = msg.value;
     if ("err" in result) {
-      const rawActual = result.err?.actual;
-      const hasActual =
-        Object.hasOwn(result.err, "actual") && rawActual !== undefined;
-      const actual = hasActual ? format(rawActual) : undefined;
-      const rawExpected = result.err?.expected;
-      const hasExpected =
-        Object.hasOwn(result.err, "expected") && rawExpected !== undefined;
-      const expected = hasExpected ? format(rawExpected) : undefined;
+      const hasActual = hasDefinedProperty(result.err, "actual");
+      const actual = hasActual ? format(result.err.actual) : undefined;
+      const hasExpected = hasDefinedProperty(result.err, "expected");
+      const expected = hasExpected ? format(result.err.expected) : undefined;
 
       const msgClone = {
         type: "result",

--- a/packages/tests/dom-test-evaluator.test.ts
+++ b/packages/tests/dom-test-evaluator.test.ts
@@ -60,6 +60,19 @@ describe("DOMTestEvaluator", () => {
       });
     });
 
+    it("should preserve falsy expected and actual values in error responses", async () => {
+      const test = "assert.strictEqual(false, 0, 'test error')";
+
+      const result = await evaluator.runTest(test);
+
+      expect(result).toMatchObject({
+        err: {
+          expected: 0,
+          actual: false,
+        },
+      });
+    });
+
     it("should test against the enclosing document", async () => {
       resetDocument();
       document.body.appendChild(document.createElement("div"));

--- a/packages/tests/dom-test-evaluator.test.ts
+++ b/packages/tests/dom-test-evaluator.test.ts
@@ -73,6 +73,19 @@ describe("DOMTestEvaluator", () => {
       });
     });
 
+    it("should preserve an empty string expected value in error responses", async () => {
+      const test = "assert.strictEqual('not empty', '', 'test error')";
+
+      const result = await evaluator.runTest(test);
+
+      expect(result).toMatchObject({
+        err: {
+          expected: "",
+          actual: "not empty",
+        },
+      });
+    });
+
     it("should test against the enclosing document", async () => {
       resetDocument();
       document.body.appendChild(document.createElement("div"));

--- a/packages/tests/has-defined-property.test.ts
+++ b/packages/tests/has-defined-property.test.ts
@@ -1,0 +1,17 @@
+import { hasDefinedProperty } from "../shared/src/has-defined-property";
+
+describe("hasDefinedProperty", () => {
+  it("returns true when the property is present and defined", () => {
+    expect(hasDefinedProperty({ expected: 0 }, "expected")).toBe(true);
+    expect(hasDefinedProperty({ expected: false }, "expected")).toBe(true);
+    expect(hasDefinedProperty({ expected: "" }, "expected")).toBe(true);
+  });
+
+  it("returns false when the property is missing", () => {
+    expect(hasDefinedProperty({}, "expected")).toBe(false);
+  });
+
+  it("returns false when the property is explicitly undefined", () => {
+    expect(hasDefinedProperty({ expected: undefined }, "expected")).toBe(false);
+  });
+});

--- a/packages/tests/integration-tests/index.test.ts
+++ b/packages/tests/integration-tests/index.test.ts
@@ -1767,6 +1767,42 @@ pattern = re.compile('l+')
       });
     });
 
+    it("should preserve falsy expected and actual values in error responses", async () => {
+      const result = await page.evaluate(async () => {
+        const runner = await window.FCCTestRunner.createTestRunner({
+          type: "python",
+        });
+        return runner?.runTest(
+          `({ test: () => assert.strictEqual(runPython('False'), 0) })`,
+        );
+      });
+
+      expect(result).toMatchObject({
+        err: {
+          expected: 0,
+          actual: false,
+        },
+      });
+    });
+
+    it("should preserve an empty string expected value in error responses", async () => {
+      const result = await page.evaluate(async () => {
+        const runner = await window.FCCTestRunner.createTestRunner({
+          type: "python",
+        });
+        return runner?.runTest(
+          `({ test: () => assert.strictEqual(runPython("'not empty'"), '') })`,
+        );
+      });
+
+      expect(result).toMatchObject({
+        err: {
+          expected: "",
+          actual: "not empty",
+        },
+      });
+    });
+
     it("should handle DataCloneErrors", async () => {
       const source = `
 import re

--- a/packages/tests/javascript-test-evaluator.test.ts
+++ b/packages/tests/javascript-test-evaluator.test.ts
@@ -90,6 +90,19 @@ const x = 1;
       });
     });
 
+    it("should preserve falsy expected and actual values in error responses", async () => {
+      const test = "assert.strictEqual(false, 0)";
+
+      const result = await evaluator.runTest(test);
+
+      expect(result).toMatchObject({
+        err: {
+          expected: 0,
+          actual: false,
+        },
+      });
+    });
+
     it("should use the init source when running a test", async () => {
       evaluator.init({ code: {}, source: "let x = 1" });
 

--- a/packages/tests/javascript-test-evaluator.test.ts
+++ b/packages/tests/javascript-test-evaluator.test.ts
@@ -103,6 +103,19 @@ const x = 1;
       });
     });
 
+    it("should preserve an empty string expected value in error responses", async () => {
+      const test = "assert.strictEqual('not empty', '')";
+
+      const result = await evaluator.runTest(test);
+
+      expect(result).toMatchObject({
+        err: {
+          expected: "",
+          actual: "not empty",
+        },
+      });
+    });
+
     it("should use the init source when running a test", async () => {
       evaluator.init({ code: {}, source: "let x = 1" });
 


### PR DESCRIPTION
This fixes the bug where failed test messages show `undefined` instead of real values like `0` or `false`.

The issue was that error values were only included when they were "truthy". That dropped valid falsy values (`0`, `false`, and empty strings) from `expected` and `actual`.

This change keeps those values by checking whether the fields exist, instead of checking whether they are truthy.

I updated this in the JavaScript, DOM, and Python evaluators, and in the clone/fallback message path. I also added regression tests for JavaScript and DOM evaluators so this does not regress.

Closes freeCodeCamp/freeCodeCamp#64229
