### PR TITLE
chore: ignore macOS .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ book
 
 # python
 __pycache__
+
+# macOS
+.DS_Store


### PR DESCRIPTION
Adds `.DS_Store` to the repository `.gitignore` so Finder metadata files are not shown as untracked changes across the repo.

This is a repo hygiene change only (no runtime behavior changes).
