### PR TITLE
feat: callbackCallRegex

### DIFF
--- a/docs/curriculum-helpers.md
+++ b/docs/curriculum-helpers.md
@@ -114,7 +114,7 @@ regex.test(
 - `source: string` — The object the method is called on.
 - `method: string` — The method name (dot notation only).
 - `params: string[]` — The callback parameter names, in order.
-- `returns?: RegExp` — Optional. When provided, the regex also enforces the callback return expression.
+- `returns?: RegExp` — Optional. When provided, the regex also enforces the callback return expression. Non-stateful flags (`d`, `i`, `m`, `s`, `u`, `v`) are preserved; stateful flags (`g`, `y`) are ignored.
 
 **Note:** Extra non-callback arguments (e.g. the initial value `, 0` in `reduce`) are not validated by this helper and should be asserted separately if needed.
 

--- a/docs/curriculum-helpers.md
+++ b/docs/curriculum-helpers.md
@@ -70,6 +70,54 @@ let match =
 match[1]; // "myFunc = arg1 => arg1; console.log();\n // captured, unfortunately"
 ```
 
+## callbackCallRegex
+
+Generates a regex to match a method call with a callback assigned to a target variable. Useful for asserting that a learner used a specific array method with the right callback shape.
+
+```javascript
+const regex = callbackCallRegex({
+  target: "sumSquaredDifferences",
+  source: "numbers",
+  method: "reduce",
+  params: ["acc", "el"],
+  returns: "acc + el ** 2",
+});
+
+// Matches arrow expression
+regex.test(
+  "sumSquaredDifferences = numbers.reduce((acc, el) => acc + el ** 2)",
+);
+// true
+
+// Matches arrow block
+regex.test(
+  "sumSquaredDifferences = numbers.reduce((acc, el) => { return acc + el ** 2; })",
+);
+// true
+
+// Matches function expression
+regex.test(
+  "sumSquaredDifferences = numbers.reduce(function (acc, el) { return acc + el ** 2; })",
+);
+// true
+
+// Also works with const/let/var declarations
+regex.test(
+  "const sumSquaredDifferences = numbers.reduce((acc, el) => acc + el ** 2)",
+);
+// true
+```
+
+### Options
+
+- `target: string` — The variable being assigned to.
+- `source: string` — The object the method is called on.
+- `method: string` — The method name (dot notation only).
+- `params: string[]` — The callback parameter names, in order.
+- `returns?: string | RegExp` — Optional. When provided, the regex also enforces the callback return expression. A `string` value will be escaped; pass a `RegExp` for complex patterns.
+
+**Note:** Extra non-callback arguments (e.g. the initial value `, 0` in `reduce`) are not validated by this helper and should be asserted separately if needed.
+
 ## prepTestComponent
 
 Renders a React component into a DOM element and returns a Promise containing the DOM element. The arguments are, respectively, the component to render and an (optional) object containing the props to pass to the component.

--- a/docs/curriculum-helpers.md
+++ b/docs/curriculum-helpers.md
@@ -80,7 +80,7 @@ const regex = callbackCallRegex({
   source: "numbers",
   method: "reduce",
   params: ["acc", "el"],
-  returns: "acc + el ** 2",
+  returns: /acc \+ el \*\* 2/,
 });
 
 // Matches arrow expression
@@ -114,7 +114,7 @@ regex.test(
 - `source: string` — The object the method is called on.
 - `method: string` — The method name (dot notation only).
 - `params: string[]` — The callback parameter names, in order.
-- `returns?: string | RegExp` — Optional. When provided, the regex also enforces the callback return expression. A `string` value will be escaped; pass a `RegExp` for complex patterns.
+- `returns?: RegExp` — Optional. When provided, the regex also enforces the callback return expression.
 
 **Note:** Extra non-callback arguments (e.g. the initial value `, 0` in `reduce`) are not validated by this helper and should be asserted separately if needed.
 

--- a/packages/helpers/lib/index.ts
+++ b/packages/helpers/lib/index.ts
@@ -703,14 +703,28 @@ export function callbackCallRegex(options: {
   returns?: RegExp;
 }): RegExp {
   const { target, source, method, params, returns } = options;
+  const identifierChar = "[\\w$]";
 
-  const targetPart = `(?:(?:const|let|var)\\s+)?${escapeRegExp(target)}\\s*=\\s*`;
-  const methodPart = `${escapeRegExp(source)}\\.${escapeRegExp(method)}\\(\\s*`;
+  const targetPart = `(?:(?:const|let|var)\\s+)?(?<!${identifierChar})${escapeRegExp(
+    target,
+  )}(?!${identifierChar})\\s*=\\s*`;
+  const methodPart = `(?<!${identifierChar})${escapeRegExp(
+    source,
+  )}(?!${identifierChar})\\.${escapeRegExp(method)}\\(\\s*`;
   const callbackSignature = functionRegex(null, params, { includeBody: false });
 
   if (returns !== undefined) {
-    const bodyPart = `\\s*(?:return\\s+)?${returns.source}\\s*[;]?\\s*\\}?`;
-    return concatRegex(targetPart, methodPart, callbackSignature, bodyPart);
+    const bodyPart = `\\s*(?:return\\s+)?(?:${returns.source})\\s*[;]?\\s*\\}?`;
+    // Preserve non-stateful flags from `returns` so flag-dependent patterns keep
+    // working when embedded in the assembled regex.
+    const returnsFlags = returns.flags.replace(/[gy]/g, "");
+    const { source } = concatRegex(
+      targetPart,
+      methodPart,
+      callbackSignature,
+      bodyPart,
+    );
+    return new RegExp(source, returnsFlags);
   }
 
   return concatRegex(targetPart, methodPart, callbackSignature);

--- a/packages/helpers/lib/index.ts
+++ b/packages/helpers/lib/index.ts
@@ -687,6 +687,38 @@ export function getFunctionParams(code: string) {
 }
 
 /**
+ * Generates a regex to match a method call with a callback, assigned to a target variable.
+ * Supports arrow expression, arrow block, and function callbacks.
+ * @param options.target - The variable being assigned to (e.g. `"result"`)
+ * @param options.source - The object the method is called on (e.g. `"numbers"`)
+ * @param options.method - The method name (e.g. `"reduce"`)
+ * @param options.params - The callback parameter names (e.g. `["acc", "el"]`)
+ * @param options.returns - Optional: enforces a return expression in the callback body
+ */
+export function callbackCallRegex(options: {
+  target: string;
+  source: string;
+  method: string;
+  params: string[];
+  returns?: string | RegExp;
+}): RegExp {
+  const { target, source, method, params, returns } = options;
+
+  const targetPart = `(?:(?:const|let|var)\\s+)?${escapeRegExp(target)}\\s*=\\s*`;
+  const methodPart = `${escapeRegExp(source)}\\.${escapeRegExp(method)}\\(\\s*`;
+  const callbackSignature = functionRegex(null, params, { includeBody: false });
+
+  if (returns !== undefined) {
+    const returnsSource =
+      returns instanceof RegExp ? returns.source : escapeRegExp(returns);
+    const bodyPart = `\\s*(?:return\\s+)?${returnsSource}\\s*[;]?\\s*\\}?`;
+    return concatRegex(targetPart, methodPart, callbackSignature, bodyPart);
+  }
+
+  return concatRegex(targetPart, methodPart, callbackSignature);
+}
+
+/**
  * Retries a test function with a specified delay between attempts
  * Useful for testing DOM elements that may not be immediately available
  * @param test - Function that returns a truthy value when the condition is met

--- a/packages/helpers/lib/index.ts
+++ b/packages/helpers/lib/index.ts
@@ -700,7 +700,7 @@ export function callbackCallRegex(options: {
   source: string;
   method: string;
   params: string[];
-  returns?: string | RegExp;
+  returns?: RegExp;
 }): RegExp {
   const { target, source, method, params, returns } = options;
 
@@ -709,9 +709,7 @@ export function callbackCallRegex(options: {
   const callbackSignature = functionRegex(null, params, { includeBody: false });
 
   if (returns !== undefined) {
-    const returnsSource =
-      returns instanceof RegExp ? returns.source : escapeRegExp(returns);
-    const bodyPart = `\\s*(?:return\\s+)?${returnsSource}\\s*[;]?\\s*\\}?`;
+    const bodyPart = `\\s*(?:return\\s+)?${returns.source}\\s*[;]?\\s*\\}?`;
     return concatRegex(targetPart, methodPart, callbackSignature, bodyPart);
   }
 

--- a/packages/tests/curriculum-helper.test.tsx
+++ b/packages/tests/curriculum-helper.test.tsx
@@ -793,6 +793,59 @@ describe("callbackCallRegex", () => {
     );
   });
 
+  it("accepts a RegExp for returns", () => {
+    const regex = callbackCallRegex({
+      ...baseOptions,
+      returns: /acc\s*\+\s*el/,
+    });
+    expect(regex.test("result = numbers.reduce((acc, el) => acc + el)")).toBe(
+      true,
+    );
+    expect(regex.test("result = numbers.reduce((acc, el) => acc  +  el)")).toBe(
+      true,
+    );
+    expect(regex.test("result = numbers.reduce((acc, el) => acc - el)")).toBe(
+      false,
+    );
+  });
+
+  it("matches a function callback with returns", () => {
+    const regex = callbackCallRegex({ ...baseOptions, returns: "acc + el" });
+    expect(
+      regex.test(
+        "result = numbers.reduce(function (acc, el) { return acc + el; })",
+      ),
+    ).toBe(true);
+    expect(
+      regex.test(
+        "result = numbers.reduce(function (acc, el) { return acc - el; })",
+      ),
+    ).toBe(false);
+  });
+
+  it("escapes special regex characters in a string returns value", () => {
+    const regex = callbackCallRegex({
+      ...baseOptions,
+      returns: "acc + el ** 2",
+    });
+    expect(
+      regex.test("result = numbers.reduce((acc, el) => acc + el ** 2)"),
+    ).toBe(true);
+    expect(regex.test("result = numbers.reduce((acc, el) => acc + el)")).toBe(
+      false,
+    );
+  });
+
+  it("matches with let and var declarations", () => {
+    const regex = callbackCallRegex({ ...baseOptions, returns: "acc + el" });
+    expect(
+      regex.test("let result = numbers.reduce((acc, el) => acc + el)"),
+    ).toBe(true);
+    expect(
+      regex.test("var result = numbers.reduce((acc, el) => acc + el)"),
+    ).toBe(true);
+  });
+
   it("works with extra whitespace in the callback signature", () => {
     const regex = callbackCallRegex({ ...baseOptions, returns: "acc + el" });
     expect(

--- a/packages/tests/curriculum-helper.test.tsx
+++ b/packages/tests/curriculum-helper.test.tsx
@@ -760,6 +760,13 @@ describe("callbackCallRegex", () => {
     );
   });
 
+  it("fails when target is only a suffix of another identifier", () => {
+    const regex = callbackCallRegex(baseOptions);
+    expect(regex.test("myresult = numbers.reduce((acc, el) => acc + el)")).toBe(
+      false,
+    );
+  });
+
   it("fails when source is different", () => {
     const regex = callbackCallRegex(baseOptions);
     expect(regex.test("result = other.reduce((acc, el) => acc + el)")).toBe(
@@ -807,6 +814,40 @@ describe("callbackCallRegex", () => {
     expect(regex.test("result = numbers.reduce((acc, el) => acc - el)")).toBe(
       false,
     );
+  });
+
+  it("scopes alternation in returns to the callback return expression", () => {
+    const regex = callbackCallRegex({
+      ...baseOptions,
+      returns: /acc \+ el|somethingElse/,
+    });
+
+    expect(regex.test("result = numbers.reduce((acc, el) => acc + el)")).toBe(
+      true,
+    );
+    expect(regex.test("somethingElse")).toBe(false);
+    expect(
+      regex.test(
+        "result = numbers.reduce((acc, el) => acc - el); somethingElse",
+      ),
+    ).toBe(false);
+  });
+
+  it("preserves non-stateful returns flags", () => {
+    expect(() =>
+      callbackCallRegex({
+        ...baseOptions,
+        returns: /\p{L}+/u,
+      }),
+    ).not.toThrow();
+
+    const regex = callbackCallRegex({
+      ...baseOptions,
+      returns: /\p{L}+/u,
+    });
+
+    expect(regex.flags).toContain("u");
+    expect(regex.test("result = numbers.reduce((acc, el) => café)")).toBe(true);
   });
 
   it("matches a function callback with returns", () => {

--- a/packages/tests/curriculum-helper.test.tsx
+++ b/packages/tests/curriculum-helper.test.tsx
@@ -731,21 +731,21 @@ describe("callbackCallRegex", () => {
   });
 
   it("matches arrow expression callback", () => {
-    const regex = callbackCallRegex({ ...baseOptions, returns: "acc + el" });
+    const regex = callbackCallRegex({ ...baseOptions, returns: /acc \+ el/ });
     expect(regex.test("result = numbers.reduce((acc, el) => acc + el)")).toBe(
       true,
     );
   });
 
   it("matches arrow block callback", () => {
-    const regex = callbackCallRegex({ ...baseOptions, returns: "acc + el" });
+    const regex = callbackCallRegex({ ...baseOptions, returns: /acc \+ el/ });
     expect(
       regex.test("result = numbers.reduce((acc, el) => { return acc + el; })"),
     ).toBe(true);
   });
 
   it("matches function callback", () => {
-    const regex = callbackCallRegex({ ...baseOptions, returns: "acc + el" });
+    const regex = callbackCallRegex({ ...baseOptions, returns: /acc \+ el/ });
     expect(
       regex.test(
         "result = numbers.reduce(function (acc, el) { return acc + el; })",
@@ -787,7 +787,7 @@ describe("callbackCallRegex", () => {
   });
 
   it("fails when return expression does not match returns", () => {
-    const regex = callbackCallRegex({ ...baseOptions, returns: "acc + el" });
+    const regex = callbackCallRegex({ ...baseOptions, returns: /acc \+ el/ });
     expect(regex.test("result = numbers.reduce((acc, el) => acc - el)")).toBe(
       false,
     );
@@ -810,7 +810,7 @@ describe("callbackCallRegex", () => {
   });
 
   it("matches a function callback with returns", () => {
-    const regex = callbackCallRegex({ ...baseOptions, returns: "acc + el" });
+    const regex = callbackCallRegex({ ...baseOptions, returns: /acc \+ el/ });
     expect(
       regex.test(
         "result = numbers.reduce(function (acc, el) { return acc + el; })",
@@ -823,10 +823,10 @@ describe("callbackCallRegex", () => {
     ).toBe(false);
   });
 
-  it("escapes special regex characters in a string returns value", () => {
+  it("matches a complex return expression using a RegExp", () => {
     const regex = callbackCallRegex({
       ...baseOptions,
-      returns: "acc + el ** 2",
+      returns: /acc \+ el \*\* 2/,
     });
     expect(
       regex.test("result = numbers.reduce((acc, el) => acc + el ** 2)"),
@@ -837,7 +837,7 @@ describe("callbackCallRegex", () => {
   });
 
   it("matches with let and var declarations", () => {
-    const regex = callbackCallRegex({ ...baseOptions, returns: "acc + el" });
+    const regex = callbackCallRegex({ ...baseOptions, returns: /acc \+ el/ });
     expect(
       regex.test("let result = numbers.reduce((acc, el) => acc + el)"),
     ).toBe(true);
@@ -847,14 +847,14 @@ describe("callbackCallRegex", () => {
   });
 
   it("works with extra whitespace in the callback signature", () => {
-    const regex = callbackCallRegex({ ...baseOptions, returns: "acc + el" });
+    const regex = callbackCallRegex({ ...baseOptions, returns: /acc \+ el/ });
     expect(
       regex.test("result = numbers.reduce(  ( acc , el )  =>  acc + el  )"),
     ).toBe(true);
   });
 
   it("works with multiline/whitespace-heavy code", () => {
-    const regex = callbackCallRegex({ ...baseOptions, returns: "acc + el" });
+    const regex = callbackCallRegex({ ...baseOptions, returns: /acc \+ el/ });
     const code = `const result = numbers.reduce(
       (acc, el) => {
         return acc + el;
@@ -877,6 +877,24 @@ describe("callbackCallRegex", () => {
         "result = numbers.reduce(function (acc, el) { return anything; })",
       ),
     ).toBe(true);
+  });
+
+  it("matches an empty callback when params is []", () => {
+    const regex = callbackCallRegex({
+      target: "result",
+      source: "numbers",
+      method: "forEach",
+      params: [],
+    });
+    expect(regex.test("result = numbers.forEach(() => doSomething())")).toBe(
+      true,
+    );
+    expect(
+      regex.test("result = numbers.forEach(function () { doSomething(); })"),
+    ).toBe(true);
+    expect(
+      regex.test("result = numbers.forEach((el) => doSomething(el))"),
+    ).toBe(false);
   });
 });
 

--- a/packages/tests/curriculum-helper.test.tsx
+++ b/packages/tests/curriculum-helper.test.tsx
@@ -717,6 +717,116 @@ describe("functionRegex", () => {
   });
 });
 
+describe("callbackCallRegex", () => {
+  const { callbackCallRegex } = helper;
+  const baseOptions = {
+    target: "result",
+    source: "numbers",
+    method: "reduce",
+    params: ["acc", "el"],
+  };
+
+  it("returns a RegExp", () => {
+    expect(callbackCallRegex(baseOptions)).toBeInstanceOf(RegExp);
+  });
+
+  it("matches arrow expression callback", () => {
+    const regex = callbackCallRegex({ ...baseOptions, returns: "acc + el" });
+    expect(regex.test("result = numbers.reduce((acc, el) => acc + el)")).toBe(
+      true,
+    );
+  });
+
+  it("matches arrow block callback", () => {
+    const regex = callbackCallRegex({ ...baseOptions, returns: "acc + el" });
+    expect(
+      regex.test("result = numbers.reduce((acc, el) => { return acc + el; })"),
+    ).toBe(true);
+  });
+
+  it("matches function callback", () => {
+    const regex = callbackCallRegex({ ...baseOptions, returns: "acc + el" });
+    expect(
+      regex.test(
+        "result = numbers.reduce(function (acc, el) { return acc + el; })",
+      ),
+    ).toBe(true);
+  });
+
+  it("fails when target is different", () => {
+    const regex = callbackCallRegex(baseOptions);
+    expect(regex.test("other = numbers.reduce((acc, el) => acc + el)")).toBe(
+      false,
+    );
+  });
+
+  it("fails when source is different", () => {
+    const regex = callbackCallRegex(baseOptions);
+    expect(regex.test("result = other.reduce((acc, el) => acc + el)")).toBe(
+      false,
+    );
+  });
+
+  it("fails when method is different", () => {
+    const regex = callbackCallRegex(baseOptions);
+    expect(regex.test("result = numbers.map((acc, el) => acc + el)")).toBe(
+      false,
+    );
+  });
+
+  it("fails when callback params are different", () => {
+    const regex = callbackCallRegex(baseOptions);
+    expect(regex.test("result = numbers.reduce((x, y) => x + y)")).toBe(false);
+  });
+
+  it("fails when callback param order is different", () => {
+    const regex = callbackCallRegex(baseOptions);
+    expect(regex.test("result = numbers.reduce((el, acc) => el + acc)")).toBe(
+      false,
+    );
+  });
+
+  it("fails when return expression does not match returns", () => {
+    const regex = callbackCallRegex({ ...baseOptions, returns: "acc + el" });
+    expect(regex.test("result = numbers.reduce((acc, el) => acc - el)")).toBe(
+      false,
+    );
+  });
+
+  it("works with extra whitespace in the callback signature", () => {
+    const regex = callbackCallRegex({ ...baseOptions, returns: "acc + el" });
+    expect(
+      regex.test("result = numbers.reduce(  ( acc , el )  =>  acc + el  )"),
+    ).toBe(true);
+  });
+
+  it("works with multiline/whitespace-heavy code", () => {
+    const regex = callbackCallRegex({ ...baseOptions, returns: "acc + el" });
+    const code = `const result = numbers.reduce(
+      (acc, el) => {
+        return acc + el;
+      },
+      0
+    )`;
+    expect(regex.test(code)).toBe(true);
+  });
+
+  it("when returns is omitted, only call shape and callback signature is required", () => {
+    const regex = callbackCallRegex(baseOptions);
+    expect(regex.test("result = numbers.reduce((acc, el) => acc + el)")).toBe(
+      true,
+    );
+    expect(regex.test("result = numbers.reduce((acc, el) => acc - el)")).toBe(
+      true,
+    );
+    expect(
+      regex.test(
+        "result = numbers.reduce(function (acc, el) { return anything; })",
+      ),
+    ).toBe(true);
+  });
+});
+
 describe("prepTestComponent", () => {
   let MyComponent;
   beforeEach(() => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)
<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This PR adds `callbackCallRegex` to reduce repeated callback regex checks in curriculum challenge tests.

A concrete example is Statistics Calculator Step 50 in freeCodeCamp:
https://github.com/freeCodeCamp/freeCodeCamp/blob/main/curriculum/challenges/english/blocks/learn-advanced-array-methods-by-building-a-statistics-calculator/6352fcb156834128001ea945.md

That step currently uses multiple separate regex assertions to verify one callback call shape:

- target assignment (`sumSquaredDifferences = ...`)
- method call (`squaredDifferences.reduce(...)`)
- callback params (`acc, el`)
- callback return (`acc + el`)

Today, those are checked with multiple `assert.match(...)` lines that all need to stay in sync.

With this helper, the same core check becomes one assertion:

```js
assert.match(
  getVariance.toString(),
  callbackCallRegex({
    target: "sumSquaredDifferences",
    source: "squaredDifferences",
    method: "reduce",
    params: ["acc", "el"],
    returns: /acc\s*\+\s*el/
  })
);
```

If the challenge also needs to enforce a second argument (like `, 0`), that can still be tested separately.

Why this is better in practice:

- fewer duplicated regex fragments per step
- easier updates when we tweak accepted callback style
- fewer brittle failures caused by one of several related regexes drifting out of sync

More places in freeCodeCamp with the same repeated callback-check pattern:

- Step 48 (map callback): https://github.com/freeCodeCamp/freeCodeCamp/blob/main/curriculum/challenges/english/blocks/learn-advanced-array-methods-by-building-a-statistics-calculator/6352faf71a9db52631864634.md
- Step 11 (reduce callback): https://github.com/freeCodeCamp/freeCodeCamp/blob/main/curriculum/challenges/english/blocks/learn-advanced-array-methods-by-building-a-statistics-calculator/635080d80b72803e973841da.md
- Music Player Step 82 (filter callback): https://github.com/freeCodeCamp/freeCodeCamp/blob/main/curriculum/challenges/english/blocks/learn-basic-string-and-array-methods-by-building-a-music-player/6555ebf07ec610585a626f72.md
