### PR TITLE
fix: functionRegex no longer replaces empty parameter

### DIFF
--- a/packages/helpers/lib/index.ts
+++ b/packages/helpers/lib/index.ts
@@ -658,7 +658,7 @@ export function getFunctionParams(code: string) {
     code.match(functionVariableRegex) ||
     code.match(arrowFunctionRegex);
 
-  if (paramMatch) {
+  if (paramMatch && paramMatch.length > 1 && paramMatch[1].trim() !== "") {
     // Find the captured group containing the parameters
     const paramString =
       paramMatch[1] || paramMatch[2] || paramMatch[3] || paramMatch[4];

--- a/packages/helpers/lib/index.ts
+++ b/packages/helpers/lib/index.ts
@@ -658,7 +658,7 @@ export function getFunctionParams(code: string) {
     code.match(functionVariableRegex) ||
     code.match(arrowFunctionRegex);
 
-  if (paramMatch && paramMatch.length > 1 && paramMatch[1].trim() !== "") {
+  if (paramMatch && paramMatch[1].trim() !== "") {
     // Find the captured group containing the parameters
     const paramString =
       paramMatch[1] || paramMatch[2] || paramMatch[3] || paramMatch[4];

--- a/packages/tests/__fixtures__/curriculum-helpers-javascript.ts
+++ b/packages/tests/__fixtures__/curriculum-helpers-javascript.ts
@@ -1,7 +1,7 @@
 const jsCodeWithSingleAndMultLineComments = `
 function nonMutatingPush(original, newItem) {
-  /* This is a 
-    multi-line comment 
+  /* This is a
+    multi-line comment
     that should be removed. */
   return original.push(newItem);
 }
@@ -27,7 +27,7 @@ function nonMutatingPush(original, newItem) {
 
 const jsCodeWithUrlUnchanged = `
 function nonMutatingPush(original, newItem) {
-  var url = 'https://freecodecamp.org'; 
+  var url = 'https://freecodecamp.org';
   return original.push(newItem);
 }`;
 
@@ -67,6 +67,10 @@ const arrowFunction = `const myFunc = name => console.log("Name")`;
 
 const destructuredArgsFunctionDeclaration = `function printFruits({a, b},c = 1, ...rest) {`;
 
+const noParameterFunctionDeclaration = `function myFunction() {`;
+
+const noParameterFunctionSpacesDeclaration = `function myFunction( ) {`;
+
 const testValues = {
   jsCodeWithSingleAndMultLineComments,
   jsCodeWithSingleAndMultLineCommentsRemoved,
@@ -81,6 +85,8 @@ const testValues = {
   letFunction,
   arrowFunction,
   destructuredArgsFunctionDeclaration,
+  noParameterFunctionDeclaration,
+  noParameterFunctionSpacesDeclaration,
 };
 
 export default testValues;

--- a/packages/tests/__fixtures__/curriculum-helpers-javascript.ts
+++ b/packages/tests/__fixtures__/curriculum-helpers-javascript.ts
@@ -1,6 +1,7 @@
 const jsCodeWithSingleAndMultLineComments = `
 function nonMutatingPush(original, newItem) {
-  /* This is a
+  /* This is a 
+    multi-line comment  
     multi-line comment
     that should be removed. */
   return original.push(newItem);
@@ -27,7 +28,7 @@ function nonMutatingPush(original, newItem) {
 
 const jsCodeWithUrlUnchanged = `
 function nonMutatingPush(original, newItem) {
-  var url = 'https://freecodecamp.org';
+  var url = 'https://freecodecamp.org'; 
   return original.push(newItem);
 }`;
 

--- a/packages/tests/__fixtures__/curriculum-helpers-javascript.ts
+++ b/packages/tests/__fixtures__/curriculum-helpers-javascript.ts
@@ -1,7 +1,6 @@
 const jsCodeWithSingleAndMultLineComments = `
 function nonMutatingPush(original, newItem) {
   /* This is a 
-    multi-line comment  
     multi-line comment
     that should be removed. */
   return original.push(newItem);

--- a/packages/tests/javascript-helper.test.ts
+++ b/packages/tests/javascript-helper.test.ts
@@ -8,6 +8,8 @@ const {
   letFunction,
   arrowFunction,
   destructuredArgsFunctionDeclaration,
+  noParameterFunctionDeclaration,
+  noParameterFunctionSpacesDeclaration,
 } = jsTestValues;
 
 describe("js-help", () => {
@@ -44,6 +46,16 @@ describe("js-help", () => {
       expect(parameters[2].name).toBe("c");
       expect(parameters[2].defaultValue).toBe("1");
       expect(parameters[3].name).toBe("...rest");
+    });
+    it("returns empty parameter array from function declaration with no parameters", () => {
+      const parameters = getFunctionParams(noParameterFunctionDeclaration);
+      expect(parameters.length).toBe(0);
+    });
+    it("returns empty parameter array from function declaration with no parameters and spaces", () => {
+      const parameters = getFunctionParams(
+        noParameterFunctionSpacesDeclaration,
+      );
+      expect(parameters.length).toBe(0);
     });
   });
 


### PR DESCRIPTION

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Discovered in https://github.com/freeCodeCamp/freeCodeCamp/issues/66633 , I added a test to ensure the helper will now behave as expected. 