### PR TITLE
fix: prevent universal selector leakage in getStyl

### DIFF
--- a/packages/helpers/lib/index.ts
+++ b/packages/helpers/lib/index.ts
@@ -490,11 +490,30 @@ export class CSSHelp {
       .map((x) => x.style);
   }
 
+  private _selectorHasUniversal(selector: string): boolean {
+    return /(^|\s|\+|>|~)\*/.test(selector);
+  }
+
   getStyle(selector: string): ExtendedStyleDeclaration | null {
-    const style = this._getStyleRules().find(
-      (ele) => ele?.selectorText === selector,
-    )?.style as ExtendedStyleDeclaration | undefined;
-    if (!style) return null;
+    const wantsUniversal = this._selectorHasUniversal(selector);
+
+    const rule = this._getStyleRules().find((ele) => {
+      if (!ele?.selectorText) return false;
+
+      const ruleHasUniversal = this._selectorHasUniversal(ele.selectorText);
+
+      // Block universal selector leakage: if the CSS rule uses * but
+      // the queried selector does not, skip this rule to prevent
+      // overly broad selectors from matching specific ones.
+      if (ruleHasUniversal && !wantsUniversal) return false;
+
+      return ele.selectorText === selector;
+    });
+
+    if (!rule) return null;
+
+    const style = rule.style as ExtendedStyleDeclaration;
+
     style.getPropVal = (prop: string, strip = false) =>
       strip
         ? style.getPropertyValue(prop).replace(/\s+/g, "")

--- a/packages/helpers/lib/index.ts
+++ b/packages/helpers/lib/index.ts
@@ -494,6 +494,14 @@ export class CSSHelp {
     return /(^|\s|\+|>|~)\*/.test(selector);
   }
 
+  private _normalizeUniversal(selector: string): string {
+    return selector
+      .replace(/^\*/, "")
+      .replace(/([+>~\s])\*/g, "$1")
+      .replace(/\s{2,}/g, " ")
+      .trim();
+  }
+
   getStyle(selector: string): ExtendedStyleDeclaration | null {
     const wantsUniversal = this._selectorHasUniversal(selector);
 
@@ -507,7 +515,10 @@ export class CSSHelp {
       // overly broad selectors from matching specific ones.
       if (ruleHasUniversal && !wantsUniversal) return false;
 
-      return ele.selectorText === selector;
+      return (
+        this._normalizeUniversal(ele.selectorText) ===
+        this._normalizeUniversal(selector)
+      );
     });
 
     if (!rule) return null;

--- a/packages/tests/__fixtures__/curriculum-helper-css.ts
+++ b/packages/tests/__fixtures__/curriculum-helper-css.ts
@@ -307,6 +307,15 @@ body {
 }
 `;
 
+export const cssStringWithUniversal = `
+span[class~="one"] *:first-of-type {
+  background-image: linear-gradient(#f93, #f93);
+}
+span.one div:first-of-type {
+  color: green;
+}
+`;
+
 const testValues = {
   cssFullExample,
   cssCodeWithCommentsRemoved,

--- a/packages/tests/css-helper.test.ts
+++ b/packages/tests/css-helper.test.ts
@@ -1,5 +1,8 @@
 // @vitest-environment jsdom
-import { cssString } from "./__fixtures__/curriculum-helper-css";
+import {
+  cssString,
+  cssStringWithUniversal,
+} from "./__fixtures__/curriculum-helper-css";
 import { CSSHelp } from "./../helpers/lib/index";
 
 describe("css-help", () => {
@@ -140,5 +143,68 @@ describe("css-help", () => {
   afterEach(() => {
     document.body.innerHTML = "";
     document.head.innerHTML = "";
+  });
+});
+
+describe("universal selector handling", () => {
+  const doc = document;
+  let t: CSSHelp;
+
+  beforeEach(() => {
+    const style = doc.createElement("style");
+    style.innerHTML = cssString + cssStringWithUniversal;
+    doc.head.appendChild(style);
+    t = new CSSHelp(doc);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    document.head.innerHTML = "";
+  });
+
+  describe("getStyle", () => {
+    it("should match when query has * and CSS has *", () => {
+      expect(t.getStyle('span[class~="one"] *:first-of-type')).toBeTruthy();
+    });
+
+    it("should return null when query has * but no matching CSS rule exists", () => {
+      expect(
+        t.getStyle('span[class~="nonexistent"] *:first-of-type'),
+      ).toBeNull();
+    });
+
+    it("should not match a * rule when query does not use *", () => {
+      expect(t.getStyle('span[class~="one"] :first-of-type')).toBeNull();
+    });
+
+    it("should match a non-* rule when query does not use *", () => {
+      expect(t.getStyle("span.one div:first-of-type")).toBeTruthy();
+    });
+  });
+
+  describe("getStyleAny", () => {
+    it("should not match * rules against non-* selectors", () => {
+      expect(
+        t.getStyleAny([
+          'span[class~="one"] :first-of-type',
+          'span[class~="one"] p:first-of-type',
+        ]),
+      ).toBeNull();
+    });
+
+    it("should match * rules when * is in the selector list", () => {
+      expect(
+        t.getStyleAny(['span[class~="one"] *:first-of-type']),
+      ).toBeTruthy();
+    });
+
+    it("should match non-* rules normally", () => {
+      expect(
+        t.getStyleAny([
+          "span.one div:first-of-type",
+          "span.one p:first-of-type",
+        ]),
+      ).toBeTruthy();
+    });
   });
 });

--- a/packages/tests/css-helper.test.ts
+++ b/packages/tests/css-helper.test.ts
@@ -183,7 +183,22 @@ describe("universal selector handling", () => {
   });
 
   describe("getStyleAny", () => {
+    it("should match when query has * and CSS has *", () => {
+      expect(
+        t.getStyleAny(['span[class~="one"] *:first-of-type']),
+      ).toBeTruthy();
+    });
+
+    it("should return null when query has * but no matching CSS rule exists", () => {
+      expect(
+        t.getStyleAny(['span[class~="nonexistent"] *:first-of-type']),
+      ).toBeNull();
+    });
+
     it("should not match * rules against non-* selectors", () => {
+      // 'span[class~="one"] :first-of-type' normalizes to the same string as
+      // the CSS rule 'span[class~="one"] *:first-of-type'; the universal
+      // selector guard must block that match.
       expect(
         t.getStyleAny([
           'span[class~="one"] :first-of-type',
@@ -192,19 +207,22 @@ describe("universal selector handling", () => {
       ).toBeNull();
     });
 
-    it("should match * rules when * is in the selector list", () => {
-      expect(
-        t.getStyleAny(['span[class~="one"] *:first-of-type']),
-      ).toBeTruthy();
-    });
-
-    it("should match non-* rules normally", () => {
+    it("should match a non-* rule when query does not use *", () => {
       expect(
         t.getStyleAny([
           "span.one div:first-of-type",
           "span.one p:first-of-type",
         ]),
       ).toBeTruthy();
+    });
+
+    it("should return null when no non-* selector matches", () => {
+      expect(
+        t.getStyleAny([
+          "span.one p:first-of-type",
+          "span.one li:first-of-type",
+        ]),
+      ).toBeNull();
     });
   });
 });


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).                                    
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like`Update index.md`)                                                                                                                  
                                                                                                                                      
Closes freeCodeCamp/freeCodeCamp#64218                                                                                              
                                                                                                                                      
CSS rules using universal selectors (`*`) like `span[class~="one"] *:first-of-type` could match queries for specific selectors that did not include `*`, causing overly broad student CSS to incorrectly pass challenge validation.                                     
                                                                                                                                      
  **Changes:**                                                                                                                        
  - Added `_selectorHasUniversal()` to detect `*` in CSS selectors                                                                    
  - Modified `getStyle()` to skip rules containing `*` when the queried selector does not use it                                      
  - Added 7 tests covering all four want/have universal selector combinations                                                         
  - Added shared CSS fixture for universal selector test cases