### PR TITLE
fix(curriculum-helpers): fixed CSSHELP issue with getStyleAny 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ book
 
 # python
 __pycache__
+
+# macOS
+.DS_Store

--- a/packages/helpers/lib/index.ts
+++ b/packages/helpers/lib/index.ts
@@ -491,9 +491,13 @@ export class CSSHelp {
   }
 
   getStyle(selector: string): ExtendedStyleDeclaration | null {
-    const style = this._getStyleRules().find(
-      (ele) => ele?.selectorText === selector,
-    )?.style as ExtendedStyleDeclaration | undefined;
+    const style = this._getStyleRules().find((ele) => {
+      // Skip rules with universal selector if the query selector doesn't use it
+      if (ele?.selectorText?.includes("*") && !selector.includes("*")) {
+        return false;
+      }
+      return ele?.selectorText === selector;
+    })?.style as ExtendedStyleDeclaration | undefined;
     if (!style) return null;
     style.getPropVal = (prop: string, strip = false) =>
       strip
@@ -658,7 +662,7 @@ export function getFunctionParams(code: string) {
     code.match(functionVariableRegex) ||
     code.match(arrowFunctionRegex);
 
-  if (paramMatch) {
+  if (paramMatch && paramMatch[1].trim() !== "") {
     // Find the captured group containing the parameters
     const paramString =
       paramMatch[1] || paramMatch[2] || paramMatch[3] || paramMatch[4];

--- a/packages/tests/__fixtures__/curriculum-helpers-javascript.ts
+++ b/packages/tests/__fixtures__/curriculum-helpers-javascript.ts
@@ -1,7 +1,7 @@
 const jsCodeWithSingleAndMultLineComments = `
 function nonMutatingPush(original, newItem) {
   /* This is a 
-    multi-line comment 
+    multi-line comment
     that should be removed. */
   return original.push(newItem);
 }
@@ -67,6 +67,10 @@ const arrowFunction = `const myFunc = name => console.log("Name")`;
 
 const destructuredArgsFunctionDeclaration = `function printFruits({a, b},c = 1, ...rest) {`;
 
+const noParameterFunctionDeclaration = `function myFunction() {`;
+
+const noParameterFunctionSpacesDeclaration = `function myFunction( ) {`;
+
 const testValues = {
   jsCodeWithSingleAndMultLineComments,
   jsCodeWithSingleAndMultLineCommentsRemoved,
@@ -81,6 +85,8 @@ const testValues = {
   letFunction,
   arrowFunction,
   destructuredArgsFunctionDeclaration,
+  noParameterFunctionDeclaration,
+  noParameterFunctionSpacesDeclaration,
 };
 
 export default testValues;

--- a/packages/tests/javascript-helper.test.ts
+++ b/packages/tests/javascript-helper.test.ts
@@ -8,6 +8,8 @@ const {
   letFunction,
   arrowFunction,
   destructuredArgsFunctionDeclaration,
+  noParameterFunctionDeclaration,
+  noParameterFunctionSpacesDeclaration,
 } = jsTestValues;
 
 describe("js-help", () => {
@@ -44,6 +46,16 @@ describe("js-help", () => {
       expect(parameters[2].name).toBe("c");
       expect(parameters[2].defaultValue).toBe("1");
       expect(parameters[3].name).toBe("...rest");
+    });
+    it("returns empty parameter array from function declaration with no parameters", () => {
+      const parameters = getFunctionParams(noParameterFunctionDeclaration);
+      expect(parameters.length).toBe(0);
+    });
+    it("returns empty parameter array from function declaration with no parameters and spaces", () => {
+      const parameters = getFunctionParams(
+        noParameterFunctionSpacesDeclaration,
+      );
+      expect(parameters.length).toBe(0);
     });
   });
 


### PR DESCRIPTION
fix(curriculum-helpers): skip universal selector rules in getStyle when queried selector has no wildcard

Checklist:

- [x] I have read freeCodeCamp's contribution guidelines.
- [x] My pull request has a descriptive title (not a vague title like Update index.md)

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/64218