### PR TITLE
fix(curriculum): prevent universal selector bypass in getStyle

### DIFF
--- a/packages/helpers/lib/index.ts
+++ b/packages/helpers/lib/index.ts
@@ -490,11 +490,87 @@ export class CSSHelp {
       .map((x) => x.style);
   }
 
+  // Grab the raw CSS text before the browser normalizes it
+  private _getRawCSSText(): string {
+    const stylesDotCss: HTMLStyleElement | null = this.doc?.querySelector(
+      "style.fcc-injected-styles",
+    );
+    const styleTag: HTMLStyleElement | null = this.doc?.querySelector(
+      "style:not([class]):not([media])",
+    );
+    return stylesDotCss?.textContent || styleTag?.textContent || "";
+  }
+
+  // Normalize a selector for comparison — collapse whitespace,
+  // strip spaces in pseudo-class args like (-n + 2) → (-n+2), etc.
+  private _normalizeSelector(selector: string): string {
+    // Remove whitespace inside parens (pseudo-class args)
+    let result = selector.replace(/\([^)]*\)/g, (match) => {
+      return match.replace(/\s+/g, "");
+    });
+    // Collapse whitespace
+    result = result.replace(/\s+/g, " ").trim();
+    // Standardize combinator spacing
+    result = result.replace(/\s*>\s*/g, " > ");
+    result = result.replace(/\s*\+\s*/g, " + ");
+    result = result.replace(/\s*~\s*/g, " ~ ");
+    // Commas
+    result = result.replace(/\s*,\s*/g, ", ");
+    return result;
+  }
+
+  // Check if a selector actually exists in the raw CSS source.
+  // Browsers strip * from selectors like *:first-of-type → :first-of-type,
+  // which can cause false matches in getStyle.
+  private _rawCSSContainsSelector(
+    rawCSS: string,
+    selector: string,
+  ): boolean {
+    const cleaned = removeCssComments(rawCSS);
+    const normalizedExpected = this._normalizeSelector(selector);
+
+    // Pull out selector blocks (everything before each {)
+    const selectorBlockRegex = /([^{}]+?)\s*\{/g;
+    let match;
+
+    while ((match = selectorBlockRegex.exec(cleaned)) !== null) {
+      const rawSelectorBlock = match[1].trim();
+
+      // Full match check (also handles comma-separated groups)
+      if (this._normalizeSelector(rawSelectorBlock) === normalizedExpected) {
+        return true;
+      }
+
+      // Also check individual selectors in comma-separated lists
+      const individualSelectors = rawSelectorBlock
+        .split(",")
+        .map((s) => this._normalizeSelector(s));
+
+      // Single selector might be part of a group
+      if (
+        !normalizedExpected.includes(",") &&
+        individualSelectors.includes(normalizedExpected)
+      ) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   getStyle(selector: string): ExtendedStyleDeclaration | null {
     const style = this._getStyleRules().find(
       (ele) => ele?.selectorText === selector,
     )?.style as ExtendedStyleDeclaration | undefined;
     if (!style) return null;
+
+    // Verify selector exists in raw CSS — browsers normalize selectors
+    // (e.g., *:first-of-type → :first-of-type) which can cause false matches
+    const rawCSS = this._getRawCSSText();
+    if (rawCSS && !this._rawCSSContainsSelector(rawCSS, selector)) {
+      return null;
+    }
+
     style.getPropVal = (prop: string, strip = false) =>
       strip
         ? style.getPropertyValue(prop).replace(/\s+/g, "")

--- a/packages/helpers/lib/index.ts
+++ b/packages/helpers/lib/index.ts
@@ -565,6 +565,7 @@ export class CSSHelp {
     return style;
   }
 
+  // A wrapper around getStyle for testing challenges where multiple CSS selectors are valid
   getStyleAny(selectors: string[]): ExtendedStyleDeclaration | null {
     for (const selector of selectors) {
       const style = this.getStyle(selector);
@@ -623,14 +624,17 @@ export class CSSHelp {
   }
 
   getStyleSheet(): CSSStyleSheet | null {
+    // TODO: Change selector to match exactly 'styles.css'
     const link: HTMLLinkElement | null = this.doc?.querySelector(
       "link[href*='styles']",
     );
 
+    // When using the styles.css tab, we add a 'fcc-injected-styles' class so we can target that. This allows users to add external scripts without them interfering
     const stylesDotCss: HTMLStyleElement | null = this.doc?.querySelector(
       "style.fcc-injected-styles",
     );
 
+    // For steps that use <style> tags, where they don't add the above class - most* browser extensions inject styles with class/media attributes, so it filters those
     const styleTag: HTMLStyleElement | null = this.doc?.querySelector(
       "style:not([class]):not([media])",
     );
@@ -656,6 +660,8 @@ export class CSSHelp {
     return Array.from(styleSheet?.cssRules || []);
   }
 
+  // Takes a CSS selector, returns all equivalent selectors from the current document
+  // or an empty array if there are no matches
   selectorsFromSelector(selector: string): string[] {
     const elements = this.doc.querySelectorAll(selector);
     const allSelectors = Array.from(elements)
@@ -680,6 +686,7 @@ export class CSSHelp {
           indirectPath.unshift(tag);
           allPaths.push([directPath.join(" > "), indirectPath.join(" ")]);
 
+          // Traverse up the DOM tree
           element = element.parentNode as Element;
         }
 
@@ -687,6 +694,7 @@ export class CSSHelp {
       })
       .flat();
 
+    // Remove duplicates
     return [...new Set(allSelectors)];
   }
 }

--- a/packages/helpers/lib/index.ts
+++ b/packages/helpers/lib/index.ts
@@ -485,71 +485,58 @@ export class CSSHelp {
   }
 
   getStyleDeclarations(selector: string): CSSStyleDeclaration[] {
+    const rawCSS = this._getRawCSSText();
+    const wantsUniversal = selector.startsWith("*");
+    const ruleHasUniversal =
+      rawCSS !== "" && !this._rawCSSContainsSelector(rawCSS, selector);
+    if (ruleHasUniversal && !wantsUniversal) return [];
+
     return this._getStyleRules()
       ?.filter((ele) => ele?.selectorText === selector)
       .map((x) => x.style);
   }
 
-  // Grab the raw CSS text before the browser normalizes it
   private _getRawCSSText(): string {
-    const stylesDotCss: HTMLStyleElement | null = this.doc?.querySelector(
-      "style.fcc-injected-styles",
-    );
-    const styleTag: HTMLStyleElement | null = this.doc?.querySelector(
-      "style:not([class]):not([media])",
-    );
-    return stylesDotCss?.textContent || styleTag?.textContent || "";
+    const ownerNode = this.getStyleSheet()?.ownerNode as
+      | HTMLElement
+      | null
+      | undefined;
+    return ownerNode?.textContent ?? "";
   }
 
-  // Normalize a selector for comparison — collapse whitespace,
-  // strip spaces in pseudo-class args like (-n + 2) → (-n+2), etc.
-  private _normalizeSelector(selector: string): string {
-    // Remove whitespace inside parens (pseudo-class args)
-    let result = selector.replace(/\([^)]*\)/g, (match) => {
-      return match.replace(/\s+/g, "");
-    });
-    // Collapse whitespace
-    result = result.replace(/\s+/g, " ").trim();
-    // Standardize combinator spacing
-    result = result.replace(/\s*>\s*/g, " > ");
-    result = result.replace(/\s*\+\s*/g, " + ");
-    result = result.replace(/\s*~\s*/g, " ~ ");
-    // Commas
-    result = result.replace(/\s*,\s*/g, ", ");
-    return result;
+  private _browserNormalizePreservingStar(selector: string): string {
+    const placeholder = "__FCC_STAR__";
+    const withPlaceholder = selector.replace(/\*(?!=)/g, placeholder);
+
+    const style = this.doc.createElement("style");
+    style.textContent = `${withPlaceholder} {}`;
+    this.doc.head.appendChild(style);
+
+    const rule = style.sheet?.cssRules[0] as CSSStyleRule;
+    const normalized = rule?.selectorText || withPlaceholder;
+
+    this.doc.head.removeChild(style);
+
+    return normalized.replace(new RegExp(placeholder, "g"), "*");
   }
 
-  // Check if a selector actually exists in the raw CSS source.
-  // Browsers strip * from selectors like *:first-of-type → :first-of-type,
-  // which can cause false matches in getStyle.
-  private _rawCSSContainsSelector(
-    rawCSS: string,
-    selector: string,
-  ): boolean {
+  private _rawCSSContainsSelector(rawCSS: string, selector: string): boolean {
     const cleaned = removeCssComments(rawCSS);
-    const normalizedExpected = this._normalizeSelector(selector);
 
-    // Pull out selector blocks (everything before each {)
     const selectorBlockRegex = /([^{}]+?)\s*\{/g;
     let match;
 
     while ((match = selectorBlockRegex.exec(cleaned)) !== null) {
       const rawSelectorBlock = match[1].trim();
 
-      // Full match check (also handles comma-separated groups)
-      if (this._normalizeSelector(rawSelectorBlock) === normalizedExpected) {
-        return true;
-      }
+      const normalizedRaw =
+        this._browserNormalizePreservingStar(rawSelectorBlock);
 
-      // Also check individual selectors in comma-separated lists
-      const individualSelectors = rawSelectorBlock
-        .split(",")
-        .map((s) => this._normalizeSelector(s));
+      const individualSelectors = normalizedRaw.split(",").map((s) => s.trim());
 
-      // Single selector might be part of a group
       if (
-        !normalizedExpected.includes(",") &&
-        individualSelectors.includes(normalizedExpected)
+        normalizedRaw === selector ||
+        individualSelectors.includes(selector)
       ) {
         return true;
       }
@@ -564,12 +551,11 @@ export class CSSHelp {
     )?.style as ExtendedStyleDeclaration | undefined;
     if (!style) return null;
 
-    // Verify selector exists in raw CSS — browsers normalize selectors
-    // (e.g., *:first-of-type → :first-of-type) which can cause false matches
     const rawCSS = this._getRawCSSText();
-    if (rawCSS && !this._rawCSSContainsSelector(rawCSS, selector)) {
-      return null;
-    }
+    const wantsUniversal = selector.startsWith("*");
+    const ruleHasUniversal =
+      rawCSS !== "" && !this._rawCSSContainsSelector(rawCSS, selector);
+    if (ruleHasUniversal && !wantsUniversal) return null;
 
     style.getPropVal = (prop: string, strip = false) =>
       strip
@@ -579,7 +565,6 @@ export class CSSHelp {
     return style;
   }
 
-  // A wrapper around getStyle for testing challenges where multiple CSS selectors are valid
   getStyleAny(selectors: string[]): ExtendedStyleDeclaration | null {
     for (const selector of selectors) {
       const style = this.getStyle(selector);
@@ -638,17 +623,14 @@ export class CSSHelp {
   }
 
   getStyleSheet(): CSSStyleSheet | null {
-    // TODO: Change selector to match exactly 'styles.css'
     const link: HTMLLinkElement | null = this.doc?.querySelector(
       "link[href*='styles']",
     );
 
-    // When using the styles.css tab, we add a 'fcc-injected-styles' class so we can target that. This allows users to add external scripts without them interfering
     const stylesDotCss: HTMLStyleElement | null = this.doc?.querySelector(
       "style.fcc-injected-styles",
     );
 
-    // For steps that use <style> tags, where they don't add the above class - most* browser extensions inject styles with class/media attributes, so it filters those
     const styleTag: HTMLStyleElement | null = this.doc?.querySelector(
       "style:not([class]):not([media])",
     );
@@ -674,8 +656,6 @@ export class CSSHelp {
     return Array.from(styleSheet?.cssRules || []);
   }
 
-  // Takes a CSS selector, returns all equivalent selectors from the current document
-  // or an empty array if there are no matches
   selectorsFromSelector(selector: string): string[] {
     const elements = this.doc.querySelectorAll(selector);
     const allSelectors = Array.from(elements)
@@ -700,7 +680,6 @@ export class CSSHelp {
           indirectPath.unshift(tag);
           allPaths.push([directPath.join(" > "), indirectPath.join(" ")]);
 
-          // Traverse up the DOM tree
           element = element.parentNode as Element;
         }
 
@@ -708,7 +687,6 @@ export class CSSHelp {
       })
       .flat();
 
-    // Remove duplicates
     return [...new Set(allSelectors)];
   }
 }

--- a/packages/tests/__fixtures__/curriculum-helper-css.ts
+++ b/packages/tests/__fixtures__/curriculum-helper-css.ts
@@ -305,6 +305,18 @@ body {
 .card:hover {
   background-color: khaki;
 }
+span[class~="one"] *:first-of-type {
+  background-image: linear-gradient(#f93, #f93);
+}
+span[class~="two"] *:nth-of-type(-n + 2) {
+  background-image: linear-gradient(#f93, #f93);
+}
+span[class~="three"] span {
+  background-image: linear-gradient(#f93, #f93);
+}
+span[class~="one"] :first-child {
+  border-color: #d61;
+}
 `;
 
 const testValues = {

--- a/packages/tests/__fixtures__/curriculum-helper-css.ts
+++ b/packages/tests/__fixtures__/curriculum-helper-css.ts
@@ -317,6 +317,9 @@ span[class~="three"] span {
 span[class~="one"] :first-child {
   border-color: #d61;
 }
+span[class~="four"] *:nth-child(2) {
+  outline: 1px solid red;
+}
 `;
 
 const testValues = {

--- a/packages/tests/css-helper.test.ts
+++ b/packages/tests/css-helper.test.ts
@@ -137,6 +137,46 @@ describe("css-help", () => {
       doc.body.appendChild(form);
     }
   });
+  describe("getStyle universal selector bypass fix", () => {
+    it("should reject *:first-of-type when querying for :first-of-type", () => {
+      // Raw CSS has *:first-of-type but browser strips the * so selectorText
+      // becomes :first-of-type — we should NOT match this
+      expect(
+        t.getStyle('span[class~="one"] :first-of-type'),
+      ).toBeNull();
+    });
+    it("should reject *:nth-of-type when querying for :nth-of-type", () => {
+      // Same deal with *:nth-of-type — browser drops the *
+      expect(
+        t.getStyle('span[class~="two"] :nth-of-type(-n+2)'),
+      ).toBeNull();
+    });
+    it("should accept exact selector match from raw CSS", () => {
+      // Exact match, no * involved — should just work
+      expect(
+        t.getStyle('span[class~="three"] span'),
+      ).toBeTruthy();
+    });
+    it("should accept selector that exists in raw CSS", () => {
+      // :first-child without * exists in raw CSS, should match
+      expect(
+        t.getStyle('span[class~="one"] :first-child'),
+      ).toBeTruthy();
+    });
+    it("should not match *:first-of-type via getStyleAny with non-star selectors", () => {
+      // None of these use * so *:first-of-type shouldn't sneak through
+      const selectors = [
+        'span[class~="one"] :first-child',
+        'span[class~="one"] :nth-child(1)',
+        'span[class~="one"] span:first-child',
+      ];
+      // :first-child exists in the CSS so getStyleAny should pick that up
+      const result = t.getStyleAny(selectors);
+      expect(result).toBeTruthy();
+      // Make sure we got :first-child (has border-color) and not *:first-of-type
+      expect(result?.getPropertyValue("border-color")).toBeTruthy();
+    });
+  });
   afterEach(() => {
     document.body.innerHTML = "";
     document.head.innerHTML = "";

--- a/packages/tests/css-helper.test.ts
+++ b/packages/tests/css-helper.test.ts
@@ -139,42 +139,35 @@ describe("css-help", () => {
   });
   describe("getStyle universal selector bypass fix", () => {
     it("should reject *:first-of-type when querying for :first-of-type", () => {
-      // Raw CSS has *:first-of-type but browser strips the * so selectorText
-      // becomes :first-of-type — we should NOT match this
-      expect(
-        t.getStyle('span[class~="one"] :first-of-type'),
-      ).toBeNull();
+      expect(t.getStyle('span[class~="one"] :first-of-type')).toBeNull();
     });
     it("should reject *:nth-of-type when querying for :nth-of-type", () => {
-      // Same deal with *:nth-of-type — browser drops the *
-      expect(
-        t.getStyle('span[class~="two"] :nth-of-type(-n+2)'),
-      ).toBeNull();
+      expect(t.getStyle('span[class~="two"] :nth-of-type(-n+2)')).toBeNull();
     });
     it("should accept exact selector match from raw CSS", () => {
-      // Exact match, no * involved — should just work
-      expect(
-        t.getStyle('span[class~="three"] span'),
-      ).toBeTruthy();
+      expect(t.getStyle('span[class~="three"] span')).toBeTruthy();
     });
     it("should accept selector that exists in raw CSS", () => {
-      // :first-child without * exists in raw CSS, should match
-      expect(
-        t.getStyle('span[class~="one"] :first-child'),
-      ).toBeTruthy();
+      expect(t.getStyle('span[class~="one"] :first-child')).toBeTruthy();
     });
     it("should not match *:first-of-type via getStyleAny with non-star selectors", () => {
-      // None of these use * so *:first-of-type shouldn't sneak through
       const selectors = [
         'span[class~="one"] :first-child',
         'span[class~="one"] :nth-child(1)',
         'span[class~="one"] span:first-child',
       ];
-      // :first-child exists in the CSS so getStyleAny should pick that up
       const result = t.getStyleAny(selectors);
       expect(result).toBeTruthy();
-      // Make sure we got :first-child (has border-color) and not *:first-of-type
       expect(result?.getPropertyValue("border-color")).toBeTruthy();
+    });
+    it("should return null via getStyleAny if all matched rules have universal selectors in raw CSS", () => {
+      const selectors = [
+        'span[class~="one"] :first-of-type',
+        'span[class~="two"] :nth-of-type(-n+2)',
+        'span[class~="four"] :nth-child(2)',
+      ];
+      const result = t.getStyleAny(selectors);
+      expect(result).toBeNull();
     });
   });
   afterEach(() => {


### PR DESCRIPTION
## Checklist:

- [x] I have read [[freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org/)](https://contribute.freecodecamp.org).
- [x] My pull request has a [[descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title)](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

Closes freeCodeCamp/freeCodeCamp#64218

### Problem
The `getStyle()` method in `CSSHelp` can return false-positive matches when learners use the universal selector (`*`) in combination with pseudo-classes (e.g., `*:first-of-type`, `*:nth-of-type(-n+2)`).

This happens because browsers normalize selectors by stripping the `*` — for example, `*:first-of-type` becomes `:first-of-type` in the parsed `selectorText`. As a result, `getStyle(':first-of-type')` incorrectly matches a rule the learner wrote as `*:first-of-type`, allowing them to bypass the intended challenge requirements.

### Solution
This PR adds robust raw CSS source cross-check to `getStyle()`:

- `_getRawCSSText()` — Retrieves the original CSS text from the `<style>` element using `this.getStyleSheet()?.ownerNode` before browser normalization.
- `_browserNormalizePreservingStar()` — Safely replaces `*` with a placeholder and uses the browser's native CSSOM to parse the raw selector. This ensures 100% accurate normalization (handling quotes, spacing, combinators) without accidentally rejecting valid code variations like `[type=text]` vs `[type="text"]`.
- `_rawCSSContainsSelector()` — Parses the raw CSS, runs the blocks through the native normalization, and verifies the queried selector actually exists in the source.

When `getStyle()` finds a match via `selectorText`, it now additionally verifies the selector exists in the raw CSS. If the raw source doesn't contain the exact selector without a universal bypass (e.g., the source has `*:first-of-type` but we're querying for `:first-of-type`), it returns `null`.

## Tests Added
- Rejects `*:first-of-type` when querying for `:first-of-type`
- Rejects `*:nth-of-type(-n+2)` when querying for `:nth-of-type(-n+2)`
- Accepts exact selector matches that exist in raw CSS
- Accepts selectors without `*` that genuinely exist in raw CSS
- Validates `getStyleAny()` doesn't leak `*`-prefixed rules through non-star selector lists
- Validates `getStyleAny()` correctly returns `null` when *all* matched rules have a universal selector in the raw CSS