### PR TITLE
fix: avoid matching normalized CSS selectors

### DIFF
--- a/packages/helpers/lib/index.ts
+++ b/packages/helpers/lib/index.ts
@@ -484,6 +484,41 @@ export class CSSHelp {
     ) as CSSStyleRule[];
   }
 
+  private _normalizeSelector(selector: string): string {
+    return selector
+      .trim()
+      .replace(/\s+/g, " ")
+      .replace(/\s*([>+~,])\s*/g, "$1")
+      .replace(/\(\s*/g, "(")
+      .replace(/\s*\)/g, ")")
+      .replace(/\s*([+-])\s*/g, "$1");
+  }
+
+  private _getAuthoredSelectors(): Set<string> | null {
+    const styleSheet = this.getStyleSheet();
+    const ownerNode =
+      styleSheet?.ownerNode ??
+      Array.from(this.doc.querySelectorAll("style")).find(
+        (style) => style.sheet === styleSheet,
+      );
+
+    if (!(ownerNode instanceof HTMLStyleElement)) {
+      return null;
+    }
+
+    const selectors = new Set<string>();
+    const css = ownerNode.textContent?.replace(/\/\*[\s\S]*?\*\//g, "") ?? "";
+    const selectorRegex = /([^{}@][^{}]*)\{/g;
+
+    for (const match of css.matchAll(selectorRegex)) {
+      for (const selector of match[1].split(",")) {
+        selectors.add(this._normalizeSelector(selector));
+      }
+    }
+
+    return selectors;
+  }
+
   getStyleDeclarations(selector: string): CSSStyleDeclaration[] {
     return this._getStyleRules()
       ?.filter((ele) => ele?.selectorText === selector)
@@ -491,8 +526,12 @@ export class CSSHelp {
   }
 
   getStyle(selector: string): ExtendedStyleDeclaration | null {
+    const authoredSelectors = this._getAuthoredSelectors();
+    const normalizedSelector = this._normalizeSelector(selector);
     const style = this._getStyleRules().find(
-      (ele) => ele?.selectorText === selector,
+      (ele) =>
+        ele?.selectorText === selector &&
+        (!authoredSelectors || authoredSelectors.has(normalizedSelector)),
     )?.style as ExtendedStyleDeclaration | undefined;
     if (!style) return null;
     style.getPropVal = (prop: string, strip = false) =>

--- a/packages/tests/css-helper.test.ts
+++ b/packages/tests/css-helper.test.ts
@@ -40,6 +40,41 @@ describe("css-help", () => {
     it("should return null", () => {
       expect(t.getStyleAny([".sun", ".earth", ".moon"])).toBeNull();
     });
+    it("should not match normalized selectors that were not provided", () => {
+      const style = doc.createElement("style");
+      style.className = "fcc-injected-styles";
+      style.innerHTML = `
+        span[class~="one"] *:first-of-type {
+          background-image: linear-gradient(#f93, #f93);
+        }
+        span[class~="two"] *:nth-of-type(-n + 2) {
+          background-image: linear-gradient(#f93, #f93);
+        }
+      `;
+      doc.head.appendChild(style);
+      Object.defineProperty(style.sheet?.cssRules[0], "selectorText", {
+        value: 'span[class~="one"] :first-of-type',
+      });
+      Object.defineProperty(style.sheet?.cssRules[1], "selectorText", {
+        value: 'span[class~="two"] :nth-of-type(-n+2)',
+      });
+      const helper = new CSSHelp(doc);
+
+      expect(
+        helper.getStyleAny([
+          'span[class~="one"] :first-of-type',
+          'span[class~="one"] span:first-of-type',
+        ]),
+      ).toBeNull();
+      expect(
+        helper.getStyleAny([
+          'span[class~="two"] :nth-of-type(-n+2)',
+          'span[class~="two"] span:nth-of-type(-n+2)',
+        ]),
+      ).toBeNull();
+
+      style.remove();
+    });
   });
   describe("isPropertyUsed", () => {
     it("should return true on existing properties", () => {


### PR DESCRIPTION
Related to freeCodeCamp/freeCodeCamp#64218

This keeps `CSSHelp.getStyle` from accepting browser-normalized selector text when the authored selector was not one of the selectors requested by a test. In particular, this prevents authored selectors like `span[class~="one"] *:first-of-type` from satisfying tests that only allow `span[class~="one"] :first-of-type` or `span[class~="one"] span:first-of-type`.

Verification:
- `pnpm exec prettier --check packages/helpers/lib/index.ts packages/tests/css-helper.test.ts`
- `pnpm exec vitest --config vitest.unit.config.mjs packages/tests/css-helper.test.ts --run`
- `pnpm exec tsc --build`