### PR TITLE
fix: preserve falsy actual/expected values in test error responses

### DIFF
--- a/packages/dom-evaluator/src/dom-test-evaluator.ts
+++ b/packages/dom-evaluator/src/dom-test-evaluator.ts
@@ -71,8 +71,8 @@ export class DOMTestEvaluator implements TestEvaluator {
       err: {
         message: error.message,
         stack: error.stack,
-        ...(!!error.expected && { expected: error.expected }),
-        ...(!!error.actual && { actual: error.actual }),
+        ...(error.expected !== undefined && { expected: error.expected }),
+        ...(error.actual !== undefined && { actual: error.actual }),
       },
     };
   }

--- a/packages/javascript-evaluator/src/javascript-test-evaluator.ts
+++ b/packages/javascript-evaluator/src/javascript-test-evaluator.ts
@@ -43,8 +43,8 @@ export class JavascriptTestEvaluator implements TestEvaluator {
       err: {
         message: error.message,
         stack: error.stack,
-        ...(!!error.expected && { expected: error.expected }),
-        ...(!!error.actual && { actual: error.actual }),
+        ...(error.expected !== undefined && { expected: error.expected }),
+        ...(error.actual !== undefined && { actual: error.actual }),
       },
     };
   }

--- a/packages/python-evaluator/src/python-test-evaluator.ts
+++ b/packages/python-evaluator/src/python-test-evaluator.ts
@@ -55,8 +55,8 @@ class PythonTestEvaluator implements TestEvaluator {
       err: {
         message: error.message,
         stack: error.stack,
-        ...(!!expected && { expected }),
-        ...(!!actual && { actual }),
+        ...(expected !== undefined && { expected }),
+        ...(actual !== undefined && { actual }),
         type: error.type,
       },
     };


### PR DESCRIPTION
## Problem

Fixes freeCodeCamp/freeCodeCamp#64229

In all three test evaluators (`javascript`, `dom`, `python`), the `#createErrorResponse` method uses `!!value` (double-negation / boolean coercion) to guard whether `actual` and `expected` are spread into the error object:

```ts
// Before — BUG: falsy values are silently dropped
...(!!error.expected && { expected: error.expected }),
...(!!error.actual   && { actual: error.actual }),
```

`!!0 === false`, `!!false === false`, `!!'' === false`, so when a test assertion fails with a falsy value (e.g. `0`, `false`, or `""`) as the actual or expected result, those properties are **never included** in the returned error object.

In `execute-challenge-saga.js` (freeCodeCamp client), the message template replacement then reads:

```js
const { actual, expected } = err;  // actual is undefined — the property was never set
newTest.message = text
  .replace('--fcc-expected--', expected)  // → "undefined"
  .replace('--fcc-actual--', actual);     // → "undefined"
```

So a camper who returns `0` from a function sees `"but found undefined"` instead of `"but found 0"`.

## Fix

Replace `!!value` with `value !== undefined` in all three evaluators. This correctly includes the property for any value that was explicitly set (including `0`, `false`, and `""`), while still omitting it when Chai didn't set it at all.

```ts
// After — correct
...(error.expected !== undefined && { expected: error.expected }),
...(error.actual   !== undefined && { actual: error.actual }),
```

### Files changed
- `packages/javascript-evaluator/src/javascript-test-evaluator.ts`
- `packages/dom-evaluator/src/dom-test-evaluator.ts`
- `packages/python-evaluator/src/python-test-evaluator.ts`

## Testing

| `actual` value | Before (shown in message) | After (shown in message) |
|---|---|---|
| `0` | `undefined` ❌ | `0` ✅ |
| `false` | `undefined` ❌ | `false` ✅ |
| `""` | `undefined` ❌ | *(empty)* ✅ |
| `undefined` (not set) | `undefined` | `undefined` (unchanged) |
| `42` | `42` | `42` (unchanged) |