### PR TITLE
fix: support arrow functions in getFunctionParams

### DIFF
--- a/packages/helpers/lib/index.ts
+++ b/packages/helpers/lib/index.ts
@@ -650,7 +650,7 @@ export function getFunctionParams(code: string) {
   const functionVariableRegex =
     /(?:\b(?:const|let|var)\s*\w+\s*=\s*(?:function)?\s*\(([^)]*)\))/;
 
-  const arrowFunctionRegex = /=\s+([^)]*)=>/;
+  const arrowFunctionRegex = /=?\s*\(?([^)]*)\)?\s*=>/;
 
   // Match the function parameters
   const paramMatch =


### PR DESCRIPTION
Checklist:

- [x] I have read the freeCodeCamp contribution guidelines.
- [x] My pull request has a descriptive title.

Closes #591

## Description

This PR updates `getFunctionParams` to correctly parse arrow function parameters.

Previously, the regex expected an assignment operator before the arrow function, which does not match the output of `Function.prototype.toString()`.

Example:

```js
const add = (list, element) => {};
console.log(add.toString());
```

Output:

```js
(list, element) => {}
```

This change makes the assignment operator (`=`) and parentheses optional in the regex so that arrow functions returned by `Function.prototype.toString()` are parsed correctly while preserving support for existing function formats.

## Testing

- Ran `npm test -- javascript-helper.test.ts`
- All 15 tests passed successfully.