### PR TITLE
fix: support stringified arrow functions in getFunctionParams

### DIFF
--- a/packages/helpers/lib/index.ts
+++ b/packages/helpers/lib/index.ts
@@ -650,7 +650,7 @@ export function getFunctionParams(code: string) {
   const functionVariableRegex =
     /(?:\b(?:const|let|var)\s*\w+\s*=\s*(?:function)?\s*\(([^)]*)\))/;
 
-  const arrowFunctionRegex = /=\s+([^)]*)=>/;
+  const arrowFunctionRegex = /(?:=\s*)?(?:\(([^)]*)\)|([a-zA-Z_$][\w$]*))\s*=>/;
 
   // Match the function parameters
   const paramMatch =
@@ -658,10 +658,12 @@ export function getFunctionParams(code: string) {
     code.match(functionVariableRegex) ||
     code.match(arrowFunctionRegex);
 
-  if (paramMatch && paramMatch[1].trim() !== "") {
-    // Find the captured group containing the parameters
-    const paramString =
-      paramMatch[1] || paramMatch[2] || paramMatch[3] || paramMatch[4];
+  // Find the captured group containing the parameters
+  const paramString = paramMatch
+    ?.slice(1)
+    .find((match): match is string => match !== undefined);
+
+  if (paramString?.trim()) {
     // Split the parameter string by commas to get individual parameters
     const params = paramString
       .replace(/[{}[\]]/g, "")

--- a/packages/tests/javascript-helper.test.ts
+++ b/packages/tests/javascript-helper.test.ts
@@ -39,6 +39,25 @@ describe("js-help", () => {
       const parameters = getFunctionParams(arrowFunction);
       expect(parameters[0].name).toBe("name");
     });
+    it("gets arguments from stringified arrow functions", () => {
+      const parameters = getFunctionParams(
+        "(param1, param2 = 'default') => {}",
+      );
+      expect(parameters[0].name).toBe("param1");
+      expect(parameters[1].defaultValue).toBe("default");
+      expect(parameters[1].name).toBe("param2");
+    });
+    it("gets arguments from arrow function toString output", () => {
+      const add = (param1: number, param2 = 2) => param1 + param2;
+      const parameters = getFunctionParams(add.toString());
+      expect(parameters[0].name).toBe("param1");
+      expect(parameters[1].defaultValue).toBe("2");
+      expect(parameters[1].name).toBe("param2");
+    });
+    it("gets arguments from stringified arrow functions without parentheses", () => {
+      const parameters = getFunctionParams("name => console.log(name)");
+      expect(parameters[0].name).toBe("name");
+    });
     it("gets arguments from a destructured function declaration", () => {
       const parameters = getFunctionParams(destructuredArgsFunctionDeclaration);
       expect(parameters[0].name).toBe("a");


### PR DESCRIPTION
Closes #591

This updates getFunctionParams so it can parse arrow functions from Function.prototype.toString(), where the function string does not include a variable assignment.

Tested with:
- pnpm test packages/tests/javascript-helper.test.ts --run
- pnpm test:unit --run
- pnpm lint