### PR TITLE
feat: add Explorer#chain and chainMatches for method-chain verification

### DIFF
--- a/packages/helpers/lib/class/explorer.ts
+++ b/packages/helpers/lib/class/explorer.ts
@@ -41,10 +41,12 @@ import {
   isAsExpression,
   isUnionTypeNode,
   Statement,
+  Expression,
   ReturnStatement,
   isBinaryExpression,
   isPropertyAccessExpression,
   isExpressionStatement,
+  isReturnStatement,
   isConstructorDeclaration,
   isNonNullExpression,
   isExpression,
@@ -156,6 +158,96 @@ function getBody(tree: Node): Node | undefined {
       return initializer.body;
     }
   }
+}
+
+type ChainLink =
+  | { call: string; args: Explorer[] }
+  | { receiver: Explorer }
+  | {
+      method: string;
+      args: Explorer[];
+      params: Explorer[];
+      body: Explorer[];
+    };
+
+// Extracts the parameters of a callback (arrow function or function expression)
+function getCallbackParams(callback: Node): Explorer[] {
+  if (!isArrowFunction(callback) && !isFunctionExpression(callback)) {
+    return [];
+  }
+
+  return callback.parameters.map((param) => new Explorer(param));
+}
+
+// Extracts the body of a callback as a list of statements (block body) or a
+// single-element list wrapping the expression (expression body)
+function getCallbackBody(callback: Node): Explorer[] {
+  if (!isArrowFunction(callback) && !isFunctionExpression(callback)) {
+    return [];
+  }
+
+  if (isBlock(callback.body)) {
+    return callback.body.statements.map((statement) =>
+      // Unwrap `return <expr>;` to its expression, so a block body's
+      // explicit return compares equal to an expression body's implicit
+      // one via matches() — same value, either way of writing it.
+      isReturnStatement(statement) && statement.expression
+        ? new Explorer(statement.expression)
+        : new Explorer(statement),
+    );
+  }
+
+  return [new Explorer(callback.body)];
+}
+
+// Flattens a chained call expression (e.g. `fetch(url).then(a).then(b)`) into
+// an ordered list of links, from the base call to the last chained method
+function flattenChain(node: Node): ChainLink[] | null {
+  // Unwrap `return <chain>;` so a chain nested in a return statement (e.g.
+  // one statement among several in a callback's block body) is still found.
+  if (isReturnStatement(node)) {
+    return node.expression ? flattenChain(node.expression) : null;
+  }
+
+  if (!isCallExpression(node)) {
+    // Not a call — the plain variable (or property access) a chain starts
+    // from, e.g. `items` in `items.filter(...)` or `array` in `array.map(...)`
+    if (isIdentifier(node) || isPropertyAccessExpression(node)) {
+      return [{ receiver: new Explorer(node) }];
+    }
+
+    return null;
+  }
+
+  // Base case: the callee is a plain identifier, e.g. `fetch(...)`
+  if (isIdentifier(node.expression)) {
+    return [
+      {
+        call: node.expression.text,
+        args: node.arguments.map((arg) => new Explorer(arg)),
+      },
+    ];
+  }
+
+  // Recursive case: the callee is `<inner>.<method>`, e.g. `<inner>.then(...)`
+  if (isPropertyAccessExpression(node.expression)) {
+    const inner = flattenChain(node.expression.expression);
+    if (!inner) {
+      return null;
+    }
+
+    const [callback] = node.arguments;
+    const link: ChainLink = {
+      method: node.expression.name.text,
+      args: node.arguments.map((arg) => new Explorer(arg)),
+      params: callback ? getCallbackParams(callback) : [],
+      body: callback ? getCallbackBody(callback) : [],
+    };
+
+    return [...inner, link];
+  }
+
+  return null;
 }
 
 type ParseContext =
@@ -1106,6 +1198,46 @@ class Explorer {
   hasNonNullAssertion(): boolean {
     if (!this.tree) return false;
     return isNonNullExpression(this.tree);
+  }
+
+  // Flattens a chained method-call expression (e.g. `fetch(url).then(a).then(b)`)
+  // into an ordered list of links. The base call is `{ call, args }`; each
+  // subsequent chained method is `{ method, params, body }`. Works whether the
+  // current node is the chain expression itself, a function whose block body
+  // contains it as a statement, or a function with an expression body that is
+  // the chain. Returns null if no such chain can be found.
+  get chain(): ChainLink[] | null {
+    if (!this.tree) {
+      return null;
+    }
+
+    const scope = getBody(this.tree) ?? this.tree;
+
+    // FindStatements handles SourceFile, Block, ModuleBlock, and
+    // CaseOrDefaultClause uniformly, so this also finds a bare chain
+    // statement (or a `return <chain>;`) sitting among other top-level
+    // statements, not just one that is the sole content of a function body.
+    const statements = findStatements(scope);
+    let candidate: Node | undefined = scope;
+    if (statements.length > 0) {
+      candidate = statements
+        .map((statement) => {
+          if (
+            isExpressionStatement(statement) ||
+            isReturnStatement(statement)
+          ) {
+            return statement.expression;
+          }
+
+          return undefined;
+        })
+        .find(
+          (expression): expression is Expression =>
+            expression !== undefined && isCallExpression(expression),
+        );
+    }
+
+    return candidate ? flattenChain(candidate) : null;
   }
 }
 

--- a/packages/helpers/lib/class/explorer.ts
+++ b/packages/helpers/lib/class/explorer.ts
@@ -209,6 +209,16 @@ function flattenChain(node: Node): ChainLink[] | null {
     return node.expression ? flattenChain(node.expression) : null;
   }
 
+  // Unwrap `x = <chain>;` / `x += <chain>;` etc. to the chain on the
+  // right-hand side.
+  if (
+    isBinaryExpression(node) &&
+    node.operatorToken.kind >= SyntaxKind.FirstAssignment &&
+    node.operatorToken.kind <= SyntaxKind.LastAssignment
+  ) {
+    return flattenChain(node.right);
+  }
+
   if (!isCallExpression(node)) {
     // Not a call — the plain variable (or property access) a chain starts
     // from, e.g. `items` in `items.filter(...)` or `array` in `array.map(...)`
@@ -1222,14 +1232,26 @@ class Explorer {
     if (statements.length > 0) {
       candidate = statements
         .map((statement) => {
+          let expression: Node | undefined;
           if (
             isExpressionStatement(statement) ||
             isReturnStatement(statement)
           ) {
-            return statement.expression;
+            expression = statement.expression;
           }
 
-          return undefined;
+          // Unwrap `x = <chain>;` / `x += <chain>;` etc. to the chain on the
+          // right-hand side, e.g. `container.innerHTML += arr.map(...).join('')`
+          if (
+            expression &&
+            isBinaryExpression(expression) &&
+            expression.operatorToken.kind >= SyntaxKind.FirstAssignment &&
+            expression.operatorToken.kind <= SyntaxKind.LastAssignment
+          ) {
+            expression = expression.right;
+          }
+
+          return expression;
         })
         .find(
           (expression): expression is Expression =>

--- a/packages/helpers/lib/index.ts
+++ b/packages/helpers/lib/index.ts
@@ -10,6 +10,120 @@ declare global {
   var IS_REACT_ACT_ENVIRONMENT: boolean;
 }
 
+type Matchable = { matches(expected: string): boolean };
+
+type MatchableChainLink =
+  | { call: string; args: Matchable[] }
+  | { receiver: Matchable }
+  | {
+      method: string;
+      args: Matchable[];
+      params: Matchable[];
+      body: Matchable[];
+    };
+
+// A single expected string, or a list of acceptable alternatives (matches if
+// any one of them matches) — e.g. ["!isNaN(el)", "!Number.isNaN(el)"]
+type ExpectedValue = string | string[];
+
+type ExpectedChainLink =
+  | { call: string; args?: ExpectedValue[] }
+  | { receiver: ExpectedValue }
+  | {
+      method: string;
+      args?: ExpectedValue[];
+      params?: ExpectedValue[];
+      body?: ExpectedValue[];
+    };
+
+function matchesExpected(
+  actual: Matchable | undefined,
+  expected: ExpectedValue,
+): boolean {
+  if (!actual) {
+    return false;
+  }
+
+  if (Array.isArray(expected)) {
+    return expected.some((alternative) => actual.matches(alternative));
+  }
+
+  return actual.matches(expected);
+}
+
+/**
+ * Compares the result of `Explorer#chain` against a declarative expected
+ * shape. Each arg/param/body/receiver entry is compared via
+ * `Explorer#matches`, so quote style and single-parameter parenthesization
+ * differences are tolerated, same as everywhere else `matches()` is used.
+ * Any entry can also be a list of acceptable alternatives, matching if any
+ * one of them matches.
+ *
+ * A method link's `args` are its raw, unprocessed arguments (useful when an
+ * argument isn't a callback, e.g. `includes(query.toLowerCase())`). Its
+ * `params`/`body` are only populated when the first argument is a callback
+ * (arrow function or function expression) — use whichever fits the call.
+ * @example
+ * chainMatches(explorer.allFunctions.initialFetch.chain, [
+ *   { call: "fetch", args: ["'https://example.com'"] },
+ *   { method: "then", params: ["res"], body: ["res.json()"] },
+ * ]);
+ * @example
+ * chainMatches(explorer.variables.filteredItems.value.chain, [
+ *   { receiver: "items" },
+ *   { method: "filter", params: ["item"], body: ["item.includes(query)"] },
+ * ]);
+ * @example
+ * chainMatches(explorer.variables.numbers.value.chain, [
+ *   { receiver: "array" },
+ *   { method: "map", args: ["Number"] },
+ * ]);
+ * @example
+ * // body[0] matches if either alternative matches
+ * chainMatches(explorer.variables.filtered.value.chain, [
+ *   { receiver: "numbers" },
+ *   {
+ *     method: "filter",
+ *     params: ["el"],
+ *     body: [["!isNaN(el)", "!Number.isNaN(el)"]],
+ *   },
+ * ]);
+ */
+export function chainMatches(
+  chain: MatchableChainLink[] | null,
+  expected: ExpectedChainLink[],
+): boolean {
+  if (!chain || chain.length !== expected.length) {
+    return false;
+  }
+
+  return chain.every((link, i) => {
+    const exp = expected[i];
+
+    if ("call" in link) {
+      return (
+        "call" in exp &&
+        link.call === exp.call &&
+        (exp.args ?? []).every((arg, j) => matchesExpected(link.args[j], arg))
+      );
+    }
+
+    if ("receiver" in link) {
+      return "receiver" in exp && matchesExpected(link.receiver, exp.receiver);
+    }
+
+    return (
+      "method" in exp &&
+      link.method === exp.method &&
+      (exp.args ?? []).every((arg, j) => matchesExpected(link.args[j], arg)) &&
+      (exp.params ?? []).every((param, j) =>
+        matchesExpected(link.params[j], param),
+      ) &&
+      (exp.body ?? []).every((line, j) => matchesExpected(link.body[j], line))
+    );
+  });
+}
+
 /**
  * The `RandomMocker` class provides functionality to mock and restore the global `Math.random` function.
  * It replaces the default random number generator with a deterministic pseudo-random number generator.

--- a/packages/tests/explorer-chain.test.ts
+++ b/packages/tests/explorer-chain.test.ts
@@ -1,0 +1,392 @@
+import { Explorer } from "../helpers/lib/class/explorer";
+import { chainMatches } from "../helpers/lib/index";
+
+describe("chain", () => {
+  it("flattens a chained call expression assigned to a function variable", () => {
+    const { allFunctions } = new Explorer(`
+      const initialFetch = async () => {
+        fetch('https://example.com')
+          .then((res) => res.json())
+          .then((data) => {
+            authorDataArr = data;
+            displayAuthors(authorDataArr.slice(startingIndex, endingIndex));
+          })
+          .catch((err) => {
+            authorContainer.innerHTML = '<p class="error-msg">Oops</p>';
+          });
+      };
+    `);
+
+    const { chain } = allFunctions.initialFetch;
+    expect(chain).toHaveLength(4);
+    expect(
+      chain?.map((link) =>
+        "call" in link ? link.call : "method" in link ? link.method : null,
+      ),
+    ).toEqual(["fetch", "then", "then", "catch"]);
+
+    const [base, firstThen, secondThen, catchLink] = chain;
+    expect(
+      "args" in base && base.args[0].matches("'https://example.com'"),
+    ).toBe(true);
+
+    expect("params" in firstThen && firstThen.params[0].matches("res")).toBe(
+      true,
+    );
+    expect("body" in firstThen && firstThen.body[0].matches("res.json()")).toBe(
+      true,
+    );
+
+    expect("body" in secondThen && secondThen.body).toHaveLength(2);
+    expect(
+      "body" in secondThen &&
+        secondThen.body[0].matches("authorDataArr = data"),
+    ).toBe(true);
+    expect(
+      "body" in secondThen &&
+        secondThen.body[1].matches(
+          "displayAuthors(authorDataArr.slice(startingIndex, endingIndex))",
+        ),
+    ).toBe(true);
+
+    expect("method" in catchLink && catchLink.method).toBe("catch");
+    expect(
+      "body" in catchLink &&
+        catchLink.body[0].matches(
+          `authorContainer.innerHTML = "<p class=\\"error-msg\\">Oops</p>"`,
+        ),
+    ).toBe(true);
+  });
+
+  it("works when the chain is the expression body of an arrow function", () => {
+    const { allFunctions } = new Explorer(
+      "const run = () => fetch('a').then((x) => x.json());",
+    );
+    const { chain } = allFunctions.run;
+    expect(chain).toHaveLength(2);
+  });
+
+  it("works on a bare chain expression, not wrapped in a function", () => {
+    const explorer = new Explorer(
+      "fetch('a').then((x) => x.json());",
+      "expression",
+    );
+    const { chain } = explorer;
+    expect(chain).toHaveLength(2);
+  });
+
+  it("finds a bare chain statement sitting among other top-level statements", () => {
+    const explorer = new Explorer(`
+      const authorContainer = document.getElementById('author-container');
+      const loadMoreBtn = document.getElementById('load-more-btn');
+
+      fetch('a')
+        .then((res) => res.json())
+        .then((data) => {
+          console.log(data);
+        });
+    `);
+
+    const { chain } = explorer;
+    expect(
+      chain?.map((link) =>
+        "call" in link ? link.call : "method" in link ? link.method : null,
+      ),
+    ).toEqual(["fetch", "then", "then"]);
+  });
+
+  it("flattens a chain that starts from a plain variable, not a call", () => {
+    const { variables } = new Explorer(
+      "const filtered = items.filter((item) => item.includes(query));",
+    );
+
+    const { chain } = variables.filtered.value;
+    expect(chain).toHaveLength(2);
+
+    const [receiverLink, methodLink] = chain;
+    expect(
+      "receiver" in receiverLink && receiverLink.receiver.matches("items"),
+    ).toBe(true);
+    expect("method" in methodLink && methodLink.method).toBe("filter");
+    expect("params" in methodLink && methodLink.params[0].matches("item")).toBe(
+      true,
+    );
+    expect(
+      "body" in methodLink &&
+        methodLink.body[0].matches("item.includes(query)"),
+    ).toBe(true);
+  });
+
+  it("flattens a multi-link chain starting from a plain variable", () => {
+    const { variables } = new Explorer(
+      "const result = array.map((el) => Number(el)).filter((n) => n > 0);",
+    );
+
+    const { chain } = variables.result.value;
+    expect(
+      chain?.map((link) =>
+        "receiver" in link
+          ? link.receiver.toString()
+          : "call" in link
+            ? link.call
+            : link.method,
+      ),
+    ).toEqual(["array", "map", "filter"]);
+  });
+
+  it("returns null for a receiver that is neither an identifier nor a property access", () => {
+    const explorer = new Explorer("(1 + 2).toString();", "expression");
+    expect(explorer.chain).toBeNull();
+  });
+
+  it("finds a chain wrapped in a return statement, among other statements", () => {
+    const { allFunctions } = new Explorer(`
+      const run = () => {
+        const unrelated = 1 + 2;
+        return items.filter((item) => item.includes(query));
+      };
+    `);
+
+    const { chain } = allFunctions.run;
+    expect(
+      chain?.map((link) =>
+        "receiver" in link
+          ? link.receiver.toString()
+          : "call" in link
+            ? link.call
+            : link.method,
+      ),
+    ).toEqual(["items", "filter"]);
+  });
+
+  it("finds a nested chain inside a callback's `return <chain>;` body", () => {
+    const { variables } = new Explorer(
+      "const filtered = items.filter((item) => { return item.toLowerCase().includes(query.toLowerCase()); });",
+    );
+
+    const [, filterLink] = variables.filtered.value.chain;
+    expect("body" in filterLink && filterLink.body).toHaveLength(1);
+
+    const nestedChain = "body" in filterLink ? filterLink.body[0].chain : null;
+    expect(
+      nestedChain?.map((link) =>
+        "receiver" in link
+          ? link.receiver.toString()
+          : "call" in link
+            ? link.call
+            : link.method,
+      ),
+    ).toEqual(["item", "toLowerCase", "includes"]);
+  });
+
+  it("tolerates bare (unparenthesized) single-parameter callbacks", () => {
+    const { allFunctions } = new Explorer(
+      "const run = () => fetch('a').then(res => res.json());",
+    );
+    const { chain } = allFunctions.run;
+    const link = chain?.[1];
+    expect(link && "params" in link && link.params[0].matches("res")).toBe(
+      true,
+    );
+  });
+
+  it("returns null when there is no call-expression chain", () => {
+    const { variables } = new Explorer("const a = 1;");
+    expect(variables.a.chain).toBeNull();
+
+    const empty = new Explorer();
+    expect(empty.chain).toBeNull();
+  });
+
+  it("returns a one-link chain for a single, non-chained call", () => {
+    const explorer = new Explorer("fetch('a');", "expression");
+    const { chain } = explorer;
+    expect(chain).toHaveLength(1);
+    expect(chain?.[0] && "call" in chain[0] && chain[0].call).toBe("fetch");
+  });
+});
+
+describe("chainMatches", () => {
+  const getChain = (code: string) => new Explorer(code, "expression").chain;
+
+  it("matches an identical chain description", () => {
+    const chain = getChain(
+      "fetch('https://example.com').then((res) => res.json())",
+    );
+
+    expect(
+      chainMatches(chain, [
+        { call: "fetch", args: ["'https://example.com'"] },
+        { method: "then", params: ["res"], body: ["res.json()"] },
+      ]),
+    ).toBe(true);
+  });
+
+  it("tolerates quote style and paren style differences, like matches()", () => {
+    const chain = getChain(
+      `fetch("https://example.com").then(res => res.json())`,
+    );
+
+    expect(
+      chainMatches(chain, [
+        { call: "fetch", args: ["'https://example.com'"] },
+        { method: "then", params: ["res"], body: ["res.json()"] },
+      ]),
+    ).toBe(true);
+  });
+
+  it("allows omitting args/params/body to only check method names", () => {
+    const chain = getChain(
+      "fetch('https://example.com').then((res) => res.json())",
+    );
+
+    expect(chainMatches(chain, [{ call: "fetch" }, { method: "then" }])).toBe(
+      true,
+    );
+  });
+
+  it("returns false when the chain is null", () => {
+    expect(chainMatches(null, [{ call: "fetch" }])).toBe(false);
+  });
+
+  it("returns false when the link count differs", () => {
+    const chain = getChain("fetch('https://example.com')");
+
+    expect(chainMatches(chain, [{ call: "fetch" }, { method: "then" }])).toBe(
+      false,
+    );
+  });
+
+  it("returns false when a method name differs", () => {
+    const chain = getChain(
+      "fetch('https://example.com').then((res) => res.json())",
+    );
+
+    expect(chainMatches(chain, [{ call: "fetch" }, { method: "catch" }])).toBe(
+      false,
+    );
+  });
+
+  it("returns false when a body statement differs", () => {
+    const chain = getChain(
+      "fetch('https://example.com').then((res) => res.json())",
+    );
+
+    expect(
+      chainMatches(chain, [
+        { call: "fetch" },
+        { method: "then", params: ["res"], body: ["res.text()"] },
+      ]),
+    ).toBe(false);
+  });
+
+  it("matches a body entry against a list of acceptable alternatives", () => {
+    const isNaNChain = getChain("numbers.filter((el) => !isNaN(el))");
+    const numberIsNaNChain = getChain(
+      "numbers.filter((el) => !Number.isNaN(el))",
+    );
+
+    const expected = [
+      { receiver: "numbers" },
+      {
+        method: "filter",
+        params: ["el"],
+        body: [["!isNaN(el)", "!Number.isNaN(el)"]],
+      },
+    ];
+
+    expect(chainMatches(isNaNChain, expected)).toBe(true);
+    expect(chainMatches(numberIsNaNChain, expected)).toBe(true);
+  });
+
+  it("rejects when none of the body alternatives match", () => {
+    const chain = getChain("numbers.filter((el) => el > 0)");
+
+    expect(
+      chainMatches(chain, [
+        { receiver: "numbers" },
+        {
+          method: "filter",
+          params: ["el"],
+          body: [["!isNaN(el)", "!Number.isNaN(el)"]],
+        },
+      ]),
+    ).toBe(false);
+  });
+
+  it("matches an args/params/receiver entry against a list of alternatives", () => {
+    const chain = getChain("array.map(String)");
+
+    expect(
+      chainMatches(chain, [
+        { receiver: ["array", "arr"] },
+        { method: "map", args: [["Number", "String"]] },
+      ]),
+    ).toBe(true);
+  });
+
+  it("matches a chain that starts from a plain variable", () => {
+    const { chain } = new Explorer(
+      "const filtered = items.filter((item) => item.includes(query));",
+    ).variables.filtered.value;
+
+    expect(
+      chainMatches(chain, [
+        { receiver: "items" },
+        { method: "filter", params: ["item"], body: ["item.includes(query)"] },
+      ]),
+    ).toBe(true);
+  });
+
+  it("returns false when the receiver differs", () => {
+    const { chain } = new Explorer(
+      "const filtered = items.filter((item) => item.includes(query));",
+    ).variables.filtered.value;
+
+    expect(
+      chainMatches(chain, [{ receiver: "otherItems" }, { method: "filter" }]),
+    ).toBe(false);
+  });
+
+  it("matches a method link's raw args when the argument isn't a callback", () => {
+    const { chain } = new Explorer("const numbers = array.map(Number);")
+      .variables.numbers.value;
+
+    expect(
+      chainMatches(chain, [
+        { receiver: "array" },
+        { method: "map", args: ["Number"] },
+      ]),
+    ).toBe(true);
+  });
+
+  it("matches a method link's raw args alongside a non-callback second argument", () => {
+    const { chain } = new Explorer(
+      "const filtered = items.filter((item) => item.toLowerCase().includes(query.toLowerCase()));",
+    ).variables.filtered.value;
+
+    const filterLink = chain?.[1];
+    const nested =
+      filterLink && "body" in filterLink ? filterLink.body[0].chain : null;
+
+    expect(
+      chainMatches(nested, [
+        { receiver: "item" },
+        { method: "toLowerCase" },
+        { method: "includes", args: ["query.toLowerCase()"] },
+      ]),
+    ).toBe(true);
+  });
+
+  it("returns false when a method link's raw args differ", () => {
+    const { chain } = new Explorer("const numbers = array.map(Number);")
+      .variables.numbers.value;
+
+    expect(
+      chainMatches(chain, [
+        { receiver: "array" },
+        { method: "map", args: ["String"] },
+      ]),
+    ).toBe(false);
+  });
+});

--- a/packages/tests/explorer-chain.test.ts
+++ b/packages/tests/explorer-chain.test.ts
@@ -159,6 +159,46 @@ describe("chain", () => {
     ).toEqual(["items", "filter"]);
   });
 
+  it("finds a chain reassigned via `=`, among other statements", () => {
+    const { allFunctions } = new Explorer(`
+      const run = () => {
+        let result;
+        const unrelated = 1 + 2;
+        result = items.filter((item) => item.includes(query));
+      };
+    `);
+
+    const { chain } = allFunctions.run;
+    expect(
+      chain?.map((link) =>
+        "receiver" in link
+          ? link.receiver.toString()
+          : "call" in link
+            ? link.call
+            : link.method,
+      ),
+    ).toEqual(["items", "filter"]);
+  });
+
+  it("finds a chain on the right-hand side of a compound assignment (+=)", () => {
+    const { allFunctions } = new Explorer(`
+      const run = () => {
+        container.innerHTML += arr.map((x) => x.toString()).join('');
+      };
+    `);
+
+    const { chain } = allFunctions.run;
+    expect(
+      chain?.map((link) =>
+        "receiver" in link
+          ? link.receiver.toString()
+          : "call" in link
+            ? link.call
+            : link.method,
+      ),
+    ).toEqual(["arr", "map", "join"]);
+  });
+
   it("finds a nested chain inside a callback's `return <chain>;` body", () => {
     const { variables } = new Explorer(
       "const filtered = items.filter((item) => { return item.toLowerCase().includes(query.toLowerCase()); });",


### PR DESCRIPTION
## Summary
- Curriculum hints that verify a chained call expression (`fetch(...).then().catch()`, `array.map().filter()`, etc.) currently hand-roll large regexes that re-derive the whole chain's structure per hint, and are brittle to quote style, parenthesization, and whitespace.
- `Explorer#chain` flattens a chained call expression into an ordered list of links, each field an `Explorer` (so `matches()`'s existing tolerance applies for free). Handles a chain starting from a called identifier (`fetch(...)`) or a plain variable/property access (`items.filter(...)`, `array.map(...)`), a chain wrapped in `return`, a chain on the right-hand side of a plain or compound assignment (`x = ...`, `x += ...`), and a chain nested among other statements.
- `chainMatches` compares a chain against a declarative expected shape. Any `args`/`params`/`body`/`receiver` entry can also be a list of acceptable alternatives.

## Test plan
- [x] `pnpm test` passes
- [x] `pnpm lint` passes
- [x] Verified end-to-end against real curriculum challenges (promise chains, array method chains, and a chain on a compound-assignment right-hand side) in the freeCodeCamp monorepo, replacing several hand-rolled regex hints